### PR TITLE
ci: set GITHUB_TOKEN in deploy env for @zerobias-com auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ jobs:
     env:
       AWS_REGION: us-east-1
       ZB_TOKEN: ${{ secrets.ZB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Set environment variables


### PR DESCRIPTION
## Summary

`.npmrc` references `\${GITHUB_TOKEN}` for the `@zerobias-com` scope on `npm.pkg.github.com`, but `deploy.yml` only exports `ZB_TOKEN` — leaving `GITHUB_TOKEN` empty and triggering a 401 on private package downloads.

## Failed run

https://github.com/zerobias-org/app/actions/runs/24678318025

```
npm ERR! 401 Unauthorized - https://npm.pkg.github.com/download/@zerobias-com/zerobias-sdk/1.1.22
```

## Fix

One-line addition to `.github/workflows/deploy.yml` env block:

```yaml
GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Uses the auto-provided workflow token — no new secret required. Works if `@zerobias-com` is readable by the zerobias-org/app workflow token (same GitHub org).

If still 401 after merge, @kevin we'll need to provision a PAT with `read:packages` as a repo or Vault secret and reference that instead.

## Test plan

- [ ] Deploy App completes without 401 on @zerobias-com packages
- [ ] App serves at `https://uat.zerobias.com/<basePath>`

Session: claude --resume "Director Parks"