### PR TITLE
ci: reuse gh-app-prod-custom-app role for uat deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,12 +39,22 @@ jobs:
       - name: Set environment variables
         shell: bash
         run: |
-          echo "ENV_NAME=${{ github.event.inputs.env-name }}" >> $GITHUB_ENV
+          ENV_NAME="${{ github.event.inputs.env-name }}"
+          echo "ENV_NAME=$ENV_NAME" >> $GITHUB_ENV
           echo "AWS_ACCOUNT_ID=${{ github.event.inputs.aws-account-id }}" >> $GITHUB_ENV
           echo "APP_NAME=${{ github.event.inputs.app-name }}" >> $GITHUB_ENV
           echo "APP_PATH=${{ github.event.inputs.app-path }}" >> $GITHUB_ENV
           echo "S3_BUCKET=${{ github.event.inputs.s3-bucket }}" >> $GITHUB_ENV
           echo "FULL_PATH=${{ github.event.inputs.app-path }}/${{ github.event.inputs.app-name }}" >> $GITHUB_ENV
+
+          # uat runs in the prod AWS account; reuse the prod IAM role until a
+          # dedicated gh-app-uat-custom-app role is provisioned. Bucket stays
+          # env-specific (app-uat-zerobias.com) via S3_BUCKET above.
+          if [ "$ENV_NAME" = "uat" ]; then
+            echo "ROLE_ENV=prod" >> $GITHUB_ENV
+          else
+            echo "ROLE_ENV=$ENV_NAME" >> $GITHUB_ENV
+          fi
 
       - name: Import secrets
         uses: hashicorp/vault-action@v2.4.3
@@ -90,7 +100,7 @@ jobs:
           bucket-override-app-name: ${{ env.PKG_NAME }}
           s3-bucket: ${{ env.S3_BUCKET }}
           aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/gh-app-${{ env.ENV_NAME }}-custom-app
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/gh-app-${{ env.ROLE_ENV }}-custom-app
 
       - name: Release announcement
         if: env.SLACK_RELEASES_WEBHOOK != ''


### PR DESCRIPTION
## Summary

`uat` branch routes to `AWS_ACCOUNT_NAME=prod` in `dispatch.yml`, but the role name is built from `ENV_NAME` (=`uat`) — producing `gh-app-uat-custom-app`. That role isn't provisioned, so OIDC fails:

```
Could not assume role with OIDC:
Not authorized to perform sts:AssumeRoleWithWebIdentity
```

## Fix

Introduce `ROLE_ENV` separate from `ENV_NAME` in `deploy.yml`. For `uat`, `ROLE_ENV=prod` (reusing the existing prod role). Everything else passes through unchanged.

Bucket stays env-specific (`app-uat-zerobias.com` via `S3_BUCKET` input) — only the IAM role is swapped.

## Caveat

This assumes `gh-app-prod-custom-app`'s trust policy permits `ref:refs/heads/uat` on `zerobias-org/app`. If it only trusts `refs/heads/main`, deploy will hit the same OIDC error and we'll know the role still needs updating (or a dedicated uat role provisioned).

## Failed run

https://github.com/zerobias-org/app/actions/runs/24678952077

## Test plan

- [ ] Merge fires dispatch; deploy reaches S3 step without OIDC error
- [ ] App syncs to `app-uat-zerobias.com/sme-mart/`
- [ ] App loads at https://uat.zerobias.com/sme-mart

Session: claude --resume "Director Parks"