### PR TITLE
docs(sme-mart): Status section — end-to-end deploy pipeline test

### DIFF
--- a/package/w3geekery/sme-mart/README.md
+++ b/package/w3geekery/sme-mart/README.md
@@ -4,6 +4,11 @@
 
 "Upwork meets Whop" for ZeroBias platform users: buyers post engagements, SMEs bid, work flows through ZB Tasks with proper RACI and Boundaries.
 
+## Status
+
+- **UAT:** initial deploy validating the publish pipeline (`zerobias-org/app:uat` → `app-uat-zerobias.com` S3 bucket → CloudFront)
+- **Prod:** not yet published — pending UAT verification and platform enrollment
+
 ## Architecture
 
 - **Framework:** Angular 21, standalone components, no NgModules, no Nx


### PR DESCRIPTION
## Summary

Minor README addition — adds a "Status" section documenting the UAT publish pipeline state.

**Primary purpose:** serves as the first package-path change after #41 merged, exercising the full publish pipeline end-to-end with all the fixes in place:

- ✅ uat dispatch routing (#35)
- ✅ SME Mart code sync (#36)
- ✅ Lockfile in sync (#37)
- ✅ Node 22 + @zerobias-com vault token (#40)
- ✅ IAM role uat→prod mapping (#41)

If this PR merges cleanly and deploys to `https://uat.zerobias.com/sme-mart`, the pipeline is validated and we can move on to the engagement-signup flow Brian asked about.

## Test plan

- [ ] Merge fires `Dispatch Deploys`
- [ ] `Deploy App` completes (no OIDC / auth / lockfile errors)
- [ ] S3 bucket `app-uat-zerobias.com` populated at `sme-mart/`
- [ ] App loads at https://uat.zerobias.com/sme-mart
- [ ] Slack #releases announcement fires

Session: claude --resume "Director Parks"