### PR TITLE
docs(sme-mart): retry UAT publish after Andrey IAM fix

### DIFF
--- a/package/w3geekery/sme-mart/README.md
+++ b/package/w3geekery/sme-mart/README.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-- **UAT:** initial deploy validating the publish pipeline (`zerobias-org/app:uat` → `app-uat-zerobias.com` S3 bucket → CloudFront)
+- **UAT:** initial deploy validating the publish pipeline (`zerobias-org/app:uat` → `app-uat-zerobias.com` S3 bucket → CloudFront). IAM role updated 2026-04-21 (Andrey) — retrying end-to-end publish.
 - **Prod:** not yet published — pending UAT verification and platform enrollment
 
 ## Architecture


### PR DESCRIPTION
## Summary

- Minimal README touch (one line in `package/w3geekery/sme-mart/README.md` Status section) to trigger the `app/uat` dispatch pipeline.
- Andrey updated the `gh-app-prod-custom-app` IAM role to grant `s3:ListBucket/Get/Put/Delete` on `app-uat-zerobias.com` (2026-04-21). Last failed deploy was https://github.com/zerobias-org/app/actions/runs/24679498611 — IAM was the blocker.
- No code changes. If this merges green and the deploy succeeds, SME Mart should be reachable at `https://uat.zerobias.com/sme-mart`.

## Test plan

- [ ] PR checks pass on uat branch
- [ ] On merge, the app/uat dispatch workflow completes successfully (S3 sync + CloudFront invalidation)
- [ ] `curl -sI https://uat.zerobias.com/sme-mart/` returns 200
- [ ] SPA loads in browser and bootstraps without 4xx/5xx on first paint

Session: `claude --resume "Director Parks"`