### PR TITLE
ci: switch uat deploy back to gh-app-uat-custom-app role

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,14 +47,10 @@ jobs:
           echo "S3_BUCKET=${{ github.event.inputs.s3-bucket }}" >> $GITHUB_ENV
           echo "FULL_PATH=${{ github.event.inputs.app-path }}/${{ github.event.inputs.app-name }}" >> $GITHUB_ENV
 
-          # uat runs in the prod AWS account; reuse the prod IAM role until a
-          # dedicated gh-app-uat-custom-app role is provisioned. Bucket stays
-          # env-specific (app-uat-zerobias.com) via S3_BUCKET above.
-          if [ "$ENV_NAME" = "uat" ]; then
-            echo "ROLE_ENV=prod" >> $GITHUB_ENV
-          else
-            echo "ROLE_ENV=$ENV_NAME" >> $GITHUB_ENV
-          fi
+          # Use the env-specific IAM role (gh-app-<env>-custom-app).
+          # Andrey provisioned gh-app-uat-custom-app on 2026-04-21 so we no longer
+          # need to piggyback on the prod role.
+          echo "ROLE_ENV=$ENV_NAME" >> $GITHUB_ENV
 
       - name: Import secrets
         uses: hashicorp/vault-action@v2.4.3


### PR DESCRIPTION
## Summary

- Revert the prod-role piggyback from #41. Andrey provisioned `gh-app-uat-custom-app` on 2026-04-21, so uat can use its own env-specific role again.
- `ROLE_ENV=$ENV_NAME` cleanly — no special-case for uat anymore.
- Supersedes PR #43 (which rode on the prod role and hit `AccessDenied on s3:ListBucket` against `app-uat-zerobias.com` at run [24732250437](https://github.com/zerobias-org/app/actions/runs/24732250437)).

## Test plan

- [ ] PR checks pass on uat branch
- [ ] On merge, the app/uat dispatch workflow completes successfully (S3 sync + CloudFront invalidation) using `gh-app-uat-custom-app`
- [ ] `curl -sI https://uat.zerobias.com/sme-mart/` returns 200
- [ ] SPA loads in browser and bootstraps without 4xx/5xx on first paint

Session: `claude --resume "Director Parks"`