### PR TITLE
docs(sme-mart): trigger uat deploy with new gh-app-uat-custom-app role

### DIFF
--- a/package/w3geekery/sme-mart/README.md
+++ b/package/w3geekery/sme-mart/README.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-- **UAT:** initial deploy validating the publish pipeline (`zerobias-org/app:uat` → `app-uat-zerobias.com` S3 bucket → CloudFront). IAM role updated 2026-04-21 (Andrey) — retrying end-to-end publish.
+- **UAT:** initial deploy validating the publish pipeline (`zerobias-org/app:uat` → `app-uat-zerobias.com` S3 bucket → CloudFront). Role `gh-app-uat-custom-app` active 2026-04-21 (Andrey + #44) — triggering end-to-end publish.
 - **Prod:** not yet published — pending UAT verification and platform enrollment
 
 ## Architecture


### PR DESCRIPTION
## Summary

- One-line README touch under `package/w3geekery/sme-mart/` to match `dispatch.yml` path filter (`package/*/*/**`) so the merge fires the Deploy App workflow on uat.
- #44 merged the role revert (uat now uses `gh-app-uat-custom-app`), but that PR only touched `.github/workflows/deploy.yml` and did not trip the dispatch filter — no deploy ran post-merge.
- This PR exists solely to trigger a deploy with the corrected role config.

## Test plan

- [ ] PR checks pass
- [ ] On merge, `Dispatch Deploys` fires on uat; `Deploy App` runs end-to-end (S3 sync + CloudFront invalidation) using `gh-app-uat-custom-app`
- [ ] `curl -sI https://uat.zerobias.com/sme-mart/` returns 200
- [ ] SPA loads in browser and bootstraps without 4xx/5xx on first paint

Session: `claude --resume "Director Parks"`