### PR TITLE
fix(sme-mart): flatten dist layout + default to uat config for deploy

### DIFF
--- a/package/w3geekery/sme-mart/angular.json
+++ b/package/w3geekery/sme-mart/angular.json
@@ -23,6 +23,10 @@
             "browser": "src/main.ts",
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
+            "outputPath": {
+              "base": "dist",
+              "browser": ""
+            },
             "assets": [
               {
                 "glob": "**/*",

--- a/package/w3geekery/sme-mart/package.json
+++ b/package/w3geekery/sme-mart/package.json
@@ -22,7 +22,7 @@
     "dev:qa": "dotenv -e .env.local -- ng serve --proxy-config proxy-qa.conf.js",
     "predev:prod": "dotenv -e .env.local -- node scripts/gen-neon-env.mjs",
     "dev:prod": "dotenv -e .env.local -- ng serve --proxy-config proxy-prod.conf.js",
-    "build": "ng build",
+    "build": "ng build --configuration uat --base-href=/sme-mart/",
     "build:prod": "ng build --configuration production",
     "build:stack": "ng build --configuration stack --base-href=/sme-mart --output-path=dist/sme-mart",
     "build:uat": "ng build --configuration uat",


### PR DESCRIPTION
## Summary

Two issues blocked the UAT deploy from actually serving the SPA (#45 merged green but the SPA wasn't reachable — CloudFront was serving the portal shell at `/sme-mart/` because S3 had no matching key).

**Issue 1: Nested dist layout.** Angular 21's `@angular/build:application` builder emits `dist/<proj>/browser/...` (SSR-aware). The deploy action (`zerobias-org/devops/actions/static-s3-app-release@main`) syncs `$APP_PATH/dist` recursively to `s3://bucket/<app>/`, landing files at `s3://bucket/sme-mart/sme-mart/browser/...` — three segments deep. Example from the last deploy log:
```
upload: .../dist/sme-mart/browser/index.html to s3://app-uat-zerobias.com/sme-mart/sme-mart/browser/index.html
```
CloudFront serves `/sme-mart/` from `s3://bucket/sme-mart/`, so no `index.html` was found at the expected key → portal shell served as fallback.

**Fix 1:** set `outputPath.browser: ""` in `angular.json` so the builder emits directly into `dist/` with no nested dirs. The peer `example-angular` package already has a flat layout via the older `@angular-devkit/build-angular:browser` builder.

**Issue 2: Wrong environment on default build.** `ng build` defaulted to `production` (per `defaultConfiguration`), picking up `environment.prod.ts` and the prod boundary ID. The deploy action hardcodes `npm run build`, so UAT deploys were shipping a prod-env bundle.

**Fix 2:** `"build": "ng build --configuration uat --base-href=/sme-mart/"` in `package.json` — now `npm run build` produces the UAT bundle with the correct base-href for CloudFront routing.

## Verification (local)

```
$ npm run build
...
Output location: .../package/w3geekery/sme-mart/dist
$ ls dist/ | head
3rdpartylicenses.txt
assets
chunk-*.js
index.html
main-*.js
$ grep -o '<base[^>]*>' dist/index.html
<base href="/sme-mart/">
```

`index.html` + all hashed bundles at `dist/` root (no nested `sme-mart/` or `browser/`), correct base-href.

## Test plan

- [ ] PR checks pass
- [ ] On merge, Dispatch Deploys fires and Deploy App runs end-to-end with `gh-app-uat-custom-app` role
- [ ] S3 upload log shows files landing at `s3://app-uat-zerobias.com/sme-mart/index.html` (single prefix)
- [ ] `curl -sI https://uat.zerobias.com/sme-mart/` returns 200 with SME Mart `<title>` and `<base href="/sme-mart/">`
- [ ] SPA bootstraps in browser; login redirect chain works; no 404 for main/chunk bundles

Session: `claude --resume "Director Parks"`