### PR TITLE
fix(sme-mart): restore flatten-dist build config — fixes broken UAT deploy from #51

### DIFF
--- a/package/w3geekery/sme-mart/angular.json
+++ b/package/w3geekery/sme-mart/angular.json
@@ -23,6 +23,10 @@
             "browser": "src/main.ts",
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
+            "outputPath": {
+              "base": "dist",
+              "browser": ""
+            },
             "assets": [
               {
                 "glob": "**/*",

--- a/package/w3geekery/sme-mart/package.json
+++ b/package/w3geekery/sme-mart/package.json
@@ -22,7 +22,7 @@
     "dev:qa": "dotenv -e .env.local -- ng serve --proxy-config proxy-qa.conf.js",
     "predev:prod": "dotenv -e .env.local -- node scripts/gen-neon-env.mjs",
     "dev:prod": "dotenv -e .env.local -- ng serve --proxy-config proxy-prod.conf.js",
-    "build": "ng build",
+    "build": "ng build --configuration uat --base-href=/sme-mart/",
     "build:prod": "ng build --configuration production",
     "build:stack": "ng build --configuration stack --base-href=/sme-mart/ --output-path=dist/sme-mart",
     "build:uat": "ng build --configuration uat",


### PR DESCRIPTION
## Summary

**HOTFIX for #51.** PR #51 deployed but produced `s3://app-uat-zerobias.com/sme-mart/sme-mart/browser/index.html` instead of `sme-mart/index.html` — `uat.zerobias.com/sme-mart/` redirects to `/not-found`.

## Root cause

The `angular.json` and `package.json` versions checked out from `poc/sme-mart` in #51 predated [PR #46](https://github.com/zerobias-org/app/pull/46) (the flatten-dist fix from 2026-04-21). Cherry-picking those files onto `upstream/uat` silently undid #46.

## Fix (2 files / +5 / -1)

- `angular.json` — restore `outputPath: { base: "dist", browser: "" }` so build emits to `dist/` root, not `dist/sme-mart/browser/`
- `package.json` — restore build script: `"build": "ng build --configuration uat --base-href=/sme-mart/"` (was bare `ng build`). SDK bumps from #51 (`zerobias-angular-client` 1.1.36, `data-utils` 1.0.33) preserved.

## Test plan

- [ ] CI green
- [ ] Merge → auto-deploy
- [ ] After CloudFront invalidation on `E23VJPBBDUCHBQ`, verify `uat.zerobias.com/sme-mart/` loads (not redirected to `/not-found`)
- [ ] Verify `s3://app-uat-zerobias.com/sme-mart/index.html` exists at the expected path (not nested)

Same root-cause family as the IAM-role situation noted in #51: `poc/sme-mart` is a long-lived branch that doesn't auto-pick-up upstream `uat` fixes. Future deploys from that source should diff against `upstream/uat` for *every* runtime config file before cherry-picking.

Session: claude --resume "Director Parks"

🤖 Generated with [Claude Code](https://claude.com/claude-code)