### PR TITLE
chore(ci): drop dev branch from dispatch.yml

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -2,7 +2,7 @@ name: Dispatch Deploys
 
 on:
   push:
-    branches: [main, qa, dev, uat]
+    branches: [main, uat, qa]
     paths:
       - 'package/*/*/**'
 
@@ -21,24 +21,27 @@ jobs:
           BRANCH=${GITHUB_REF##*/}
           echo "BRANCH_NAME=$BRANCH" >> $GITHUB_ENV
 
-          if [[ "$BRANCH" == "main" || "$BRANCH" == "uat" ]]; then
-            echo "AWS_ACCOUNT_NAME=prod" >> $GITHUB_ENV
-            if [[ "$BRANCH" == "uat" ]]; then
+          case "$BRANCH" in
+            main)
+              echo "ENV_NAME=prod" >> $GITHUB_ENV
+              echo "AWS_ACCOUNT_NAME=prod" >> $GITHUB_ENV
+              echo "DNS_HOST=app" >> $GITHUB_ENV
+              ;;
+            uat)
               echo "ENV_NAME=uat" >> $GITHUB_ENV
+              echo "AWS_ACCOUNT_NAME=prod" >> $GITHUB_ENV
               echo "DNS_HOST=uat" >> $GITHUB_ENV
-            else
-               echo "ENV_NAME=prod" >> $GITHUB_ENV
-               echo "DNS_HOST=app" >> $GITHUB_ENV
-            fi
-          else
-            echo "ENV_NAME=$BRANCH" >> $GITHUB_ENV
-            echo "AWS_ACCOUNT_NAME=dev" >> $GITHUB_ENV
-            if [[ "$BRANCH" == "dev" ]]; then
-              echo "DNS_HOST=ci" >> $GITHUB_ENV
-            else
+              ;;
+            qa)
+              echo "ENV_NAME=qa" >> $GITHUB_ENV
+              echo "AWS_ACCOUNT_NAME=dev" >> $GITHUB_ENV
               echo "DNS_HOST=qa" >> $GITHUB_ENV
-            fi
-          fi
+              ;;
+            *)
+              echo "::error::Unsupported branch '$BRANCH'. Supported: main, uat, qa"
+              exit 1
+              ;;
+          esac
 
       - name: Import secrets
         uses: hashicorp/vault-action@v2.4.3


### PR DESCRIPTION
## Summary
Removes `dev` from the `Dispatch Deploys` workflow — `zerobias-org/app` is main/uat/qa only.

(Branch name is misleading — `add-uat` is no-op since uat was already added in commit bf679ec on 2026-04-20. The actual change is just dropping dev.)

## Changes
- `branches: [main, qa, dev, uat]` -> `[main, uat, qa]`
- env-derivation switch refactored to a `case` statement; dev case removed; explicit error for unsupported branches

## Why
Per project convention: zerobias-org/app does not deploy to dev. The dev branch in the trigger list was leftover from earlier setup; no `gh-zb-org-app-dev-*` resources are in scope and any push to dev would silently dispatch a deploy that has no AWS target.

## Test plan
- [x] YAML parses clean (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] On merge: pushes to dev no longer trigger Dispatch Deploys
- [ ] Pushes to main/uat/qa continue to dispatch correctly (no behavior change for those branches)