### PR TITLE
fix(sme-mart): add e2e typed-lint config to fix parse errors on uat

### DIFF
--- a/package/w3geekery/sme-mart/e2e/tsconfig.json
+++ b/package/w3geekery/sme-mart/e2e/tsconfig.json
@@ -1,0 +1,18 @@
+/* TypeScript project for the Playwright e2e suite. Used by eslint typed-linting
+   (see eslint.config.js e2e override) and IDE tooling. Playwright itself
+   transpiles specs via esbuild at runtime and does not require this file. */
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../out-tsc/e2e",
+    "types": ["node"],
+    // Relax two Angular-app strictness knobs that are noise for a Playwright
+    // suite (env access via process.env.FOO; page-object method overrides).
+    // The suite runs via esbuild, not tsc, and is not part of any tsc gate.
+    "noPropertyAccessFromIndexSignature": false,
+    "noImplicitOverride": false
+  },
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/package/w3geekery/sme-mart/eslint.config.js
+++ b/package/w3geekery/sme-mart/eslint.config.js
@@ -141,6 +141,31 @@ export default [
     }
   },
 
+  // Playwright e2e suite (separate e2e/tsconfig.json that includes e2e/**).
+  // Must come AFTER the **/*.spec.ts block so its `project` wins for e2e specs —
+  // tsconfig.spec.json does NOT include e2e/**, so without this they fail to parse.
+  // Not Angular code: disable the Angular modernization rules.
+  {
+    files: ['e2e/**/*.ts'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: './e2e/tsconfig.json',
+        sourceType: 'module',
+        ecmaVersion: 'latest'
+      }
+    },
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+      '@angular-eslint': angularPlugin
+    },
+    rules: {
+      '@angular-eslint/prefer-standalone': 'off',
+      '@angular-eslint/prefer-inject': 'off',
+      '@angular-eslint/prefer-signals': 'off'
+    }
+  },
+
   // Template files
   {
     files: ['**/*.html'],


### PR DESCRIPTION
## What

Ports the known-good e2e typed-lint config from `poc/sme-mart` to `uat` (two files):

- **`eslint.config.js`** — adds the `e2e/**/*.ts` override (`project: ./e2e/tsconfig.json`), placed after the spec block so its project wins for e2e specs. Angular modernization rules disabled for the non-Angular Playwright suite.
- **`e2e/tsconfig.json`** (new) — extends the base tsconfig, includes `e2e/**`.

## Why

uat has 27 Playwright e2e files but was missing both the config override and the `e2e/tsconfig.json` it references. Under typed-linting the e2e files fail with:

```
Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser.
The file was not found in any of the provided project(s): e2e/...
```

That's the **25 parse errors** surfaced in PR #57's lint run (whose wide diff swept the whole sme-mart tree).

## Scope

Deliberately narrow: **the e2e parse-error class only.** Does **not** touch the pre-existing `no-explicit-any` / `no-unused-vars` backlog (MODERN-CLEANUP-1) — that's tracked separately and intentionally left per that policy.

Config is verbatim-identical to `poc/sme-mart`, where it's been proven in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)