### PR TITLE
docs(agents): comment/doc standing order — lockstep with features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,15 @@ Common message types: `APP_NAV`, `RESOURCE_NAV`, `LOGOUT`, `REFRESH_NAVIGATION`,
 
 ## App development best practices
 
+- **Docs & comments are the product (standing order)** — these example/demo
+  apps are the canonical teaching source a 3rd-party developer reads to adopt
+  the ZeroBias client/SDK. Comments, in-code LLM notes, and each app's
+  `AGENTS.md` / `docs/` exist to enable customers to adopt our patterns faster,
+  not merely to explain the code to maintainers. Keep them current **in lockstep
+  with every feature** — a new pattern lands together with its explanatory
+  comments, its doc entry, and its LLM notes in the *same* change. Never defer
+  to a batch "comment/doc pass" before promoting: that turns merge-up into a
+  heavy lift and lets the teaching drift out of sync with the code.
 - **Auth/session** — check auth state before API calls; handle session
   expiration gracefully; support both iframe and standalone modes.
 - **API calls** — always go through the client/SDK, never hand-roll `fetch` to

--- a/package/zerobias/example-nextjs-v2/AGENTS.md
+++ b/package/zerobias/example-nextjs-v2/AGENTS.md
@@ -21,6 +21,10 @@ older `example-nextjs`, which predates v2 and carries anti-patterns.
   **with teardown** — always `return () => sub.unsubscribe()` in `useEffect`.
 - **DO** keep all client usage in `"use client"` components. The client touches
   `window`/`WebSocket`; it must never run during static-export prerender.
+- **DO** keep comments, in-code LLM notes, and docs current **with every
+  feature** — this app is canonical teaching source; update them in the same
+  change, never a deferred pass (root
+  [AGENTS.md](../../../AGENTS.md) "App development best practices" standing order).
 - **DON'T** build a login page — the client redirects to platform SSO itself
   (see [docs/authentication.md](./docs/authentication.md)).
 - **DON'T** duplicate SDK model types (`WhoAmI`, `Org`, `ProductExtended`) with


### PR DESCRIPTION
## What

Persists the **comment/doc posture** as a standing order so it stays continuous instead of a heavy pre-merge batch pass.

- **Root `AGENTS.md`** (`## App development best practices`) — repo-wide standing order: the example/demo apps are canonical teaching source; comments, in-code LLM notes, and per-app docs are part of the product (they exist to help customers adopt our client/SDK patterns faster). Update them **in lockstep with every feature**, never defer to a batch pass before promoting.
- **`example-nextjs-v2/AGENTS.md`** (`## Golden rules`) — one-line echo pointing at the root standing order.

## Flow

Lands on **uat**; promotes to qa/prod with the next app promotion (no separate sync PRs). Root `AGENTS.md` is not a `package/**` path so it doesn't deploy on its own; the app `AGENTS.md` line rides the app's promotion build.

## Test plan

- [x] Docs-only change — renders correctly, relative link `../../../AGENTS.md` resolves from the app dir to repo root.
- [ ] Clark merges into uat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)