### PR TITLE
feat(example-nextjs-v2): promote phase 2 (v0.2.0) to qa

### DIFF
--- a/package/zerobias/example-nextjs-v2/.npmrc
+++ b/package/zerobias/example-nextjs-v2/.npmrc
@@ -1,11 +1,19 @@
-# Both @zerobias-com and @zerobias-org packages resolve from pkg.zerobias.org,
-# which proxies GitHub Packages for the @zerobias-com scope. A single ZB_TOKEN
-# authenticates both scopes — matching what CI provides (deploy.yml sets ZB_TOKEN).
+# All ZeroBias scopes resolve from pkg.zerobias.org. @zerobias-com/@zerobias-org
+# are the v2 platform SDKs; @auditlogic carries the per-module clients (e.g. the
+# GitHub module, @auditlogic/module-github-github). A single ZB_TOKEN authenticates
+# them all — matching what CI provides (deploy.yml sets ZB_TOKEN).
 #
 # Get a ZB_TOKEN by creating an API key in the ZeroBias platform, then:
 #   export ZB_TOKEN='<your api key>'
 # before running `npm install`.
 @zerobias-com:registry=https://pkg.zerobias.org
 @zerobias-org:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
 //pkg.zerobias.org/:always-auth=true
 //pkg.zerobias.org/:_authToken=${ZB_TOKEN}
+
+# The GitHub Hub SDK (@auditlogic/hub-sdk-github-github) publishes stale `^1.x`
+# peerDependencies while its real deps are the v2 (@zerobias-org ^2) stack, so a
+# strict install errors on the mismatch. legacy-peer-deps skips that check — CI
+# and local both need it until the SDK's peerDeps are corrected upstream.
+legacy-peer-deps=true

--- a/package/zerobias/example-nextjs-v2/AGENTS.md
+++ b/package/zerobias/example-nextjs-v2/AGENTS.md
@@ -21,6 +21,10 @@ older `example-nextjs`, which predates v2 and carries anti-patterns.
   **with teardown** — always `return () => sub.unsubscribe()` in `useEffect`.
 - **DO** keep all client usage in `"use client"` components. The client touches
   `window`/`WebSocket`; it must never run during static-export prerender.
+- **DO** keep comments, in-code LLM notes, and docs current **with every
+  feature** — this app is canonical teaching source; update them in the same
+  change, never a deferred pass (root
+  [AGENTS.md](../../../AGENTS.md) "App development best practices" standing order).
 - **DON'T** build a login page — the client redirects to platform SSO itself
   (see [docs/authentication.md](./docs/authentication.md)).
 - **DON'T** duplicate SDK model types (`WhoAmI`, `Org`, `ProductExtended`) with
@@ -50,7 +54,11 @@ Read the doc for the feature you're touching before changing it:
 | Products catalog (read) | [docs/products-catalog.md](./docs/products-catalog.md) | `portalClient.getProductApi().search()` |
 | Principal Key-Value (read + write) | [docs/pkv.md](./docs/pkv.md) | `danaClient.getPkvApi().listPrincipalKeyValues()` / `.upsertPrincipalKeyValue()` |
 | Create API key | [docs/api-keys.md](./docs/api-keys.md) | `danaClient.getMeApi().createApiKey()` |
+| Shared session keys | [docs/shared-session-keys.md](./docs/shared-session-keys.md) | `danaClient.getMeApi().createSharedSessionKey()` |
+| Module chain (GitHub via Hub) | [docs/module-chain.md](./docs/module-chain.md) | `new GithubHubImpl().connect(new HubConnectionProfile(...))` |
+| Loading & status UI | [docs/loading-and-status.md](./docs/loading-and-status.md) | `PageLoader` (0 mark), `Spinner`, `TableSkeleton`, `ButtonLabel`, `StatusDot` |
 | Environments + deploy | [docs/environments-and-deploy.md](./docs/environments-and-deploy.md) | one build -> uat/qa/prod |
+| Theming (light/dark, portal parity) | [docs/theming.md](./docs/theming.md) | `dark-theme` class + `zb-theme-preference` (ports `ZbThemeService`) |
 
 ## Registries / install
 
@@ -71,8 +79,17 @@ npm run dev                               # http://localhost:3000
 - **Phase 1 (this milestone):** auth gate, identity + org switch, products
   search, PKV read/write, create API key.
 - **Phase 2:** GitHub module chain (product -> module -> connection -> scope ->
-  hub module client), shared-session key, Data Explorer (`@zerobias-org/data-utils`).
-- **Phase 2/3:** FileService example.
+  hub module client), shared-session key.
+- **Phase 3:** SDK building-blocks showcase in the ngx-library **side-panel
+  navigation** pattern (not top tabs). Under consideration:
+  - **Infinite-scroll** example against a cursor-wired search endpoint —
+    `PagedResults` already exposes the machinery (`pageToken`, `paginationMode`,
+    `asyncGenerator()`/`forEach()`). Note: `portalClient.getProductApi().search()`
+    is **offset-only** (no `count`, `link`, or `pageToken` returned), so the
+    Products page stays classic prev/next; this demo needs a different,
+    token-emitting endpoint.
+  - **Data Explorer** (`@zerobias-org/data-utils`).
+  - **FileService** example.
 
 Full plan: `.claude/plans/phase-1-canonical-usage.md` (git-ignored).
 

--- a/package/zerobias/example-nextjs-v2/CHANGELOG.md
+++ b/package/zerobias/example-nextjs-v2/CHANGELOG.md
@@ -14,7 +14,56 @@ the changes into their own app easier.
 
 ## [Unreleased]
 
-_Nothing yet._
+## [0.2.0] - 2026-07-09
+
+Phase 2 — the GitHub **module chain** and **shared-session key**, plus
+portal-parity theming, an accessible org switcher, the loading/status UI kit,
+error handling, and the unit-test harness.
+
+### Added — features and the calls they demonstrate
+
+- **Module chain — GitHub via the Hub** (`/module`, `src/app/module/page.tsx`) —
+  walks `product -> module -> connection -> scope -> hub client` and lists a
+  GitHub org's repositories through the Hub. The payoff hop:
+  `new GithubHubImpl().connect(new HubConnectionProfile(server, targetId, apiKey?, session?, orgId?))`,
+  then `getOrganizationApi().listMyOrganizations()` / `.listRepositories(...)`.
+  The Hub holds the GitHub credentials — the browser never sees a token. SDK:
+  **`@auditlogic/hub-sdk-github-github`** (+ `@zerobias-org/util-connector`).
+  See [docs/module-chain.md](./docs/module-chain.md).
+- **Shared-session keys** (`src/components/CreateSharedSessionDialog.tsx`) —
+  `danaClient.getMeApi().createSharedSessionKey(new CreateSharedSessionKeyBody(undefined, new Duration("PT<n>M")))`.
+  See [docs/shared-session-keys.md](./docs/shared-session-keys.md).
+- **Portal-parity theming** (`src/lib/theme.ts`) — a port of ngx-library's
+  `ZbThemeService`: a `useTheme` hook, `zb-theme-preference` storage, light
+  default + a `dark-theme` class on `<html>`/`<body>`, a pre-paint FOWT script,
+  and iframe `theme_change` follow. See [docs/theming.md](./docs/theming.md).
+- **Accessible org switcher** (`src/components/OrgSwitcher.tsx`) — a WAI-ARIA
+  listbox (keyboard nav, `aria-activedescendant`) replacing the native `<select>`,
+  driven by the pure `src/lib/listbox-nav.ts` helper.
+- **Loading & status UI kit** — `PageLoader` (the branded "0" preloader),
+  `Spinner` (mat-spinner equivalent), `TableSkeleton`, `ButtonLabel` (port of
+  `zb-ui-button-label`; also blocks repeat clicks), and `StatusDot` (port of
+  ngx-library `zb-resource-status` — connection status as a solid/outlined
+  colored dot, via the pure `src/lib/status-tone.ts` mapping). `ConnectionPicker`
+  renders the module chain's connections with status dots.
+  See [docs/loading-and-status.md](./docs/loading-and-status.md).
+- **Unit test harness** — Vitest (`npm test` / `npm run test:watch`) with suites
+  for `errors`, `listbox-nav`, and `status-tone` (26 tests).
+- **`src/lib/errors.ts`** — `toUserMessage(err)` maps any thrown value to a
+  safe, user-facing message.
+
+### Changed
+
+- **Error handling** — the Products, PKV, and Create-API-Key views now show a
+  mapped, friendly message via `toUserMessage()` and log the raw error to the
+  console for developers, instead of rendering raw error text (which can leak
+  backend detail) directly in the UI.
+- **Loading feedback** — `AuthGate` shows the branded `PageLoader`; the Products
+  and PKV tables show skeleton rows + a spinner while loading; action buttons
+  swap their label for a spinner while an action runs.
+- **`.npmrc`** — sets `legacy-peer-deps=true`: the GitHub Hub SDK publishes stale
+  `^1.x` peerDependencies while its real deps are the v2 stack. To be dropped
+  once the SDK's peerDeps are corrected upstream.
 
 ## [0.1.0] - 2026-07-08
 

--- a/package/zerobias/example-nextjs-v2/README.md
+++ b/package/zerobias/example-nextjs-v2/README.md
@@ -57,6 +57,14 @@ npm run preview    # serve dist/ locally
 The same `dist/` is promoted to uat / qa / prod — the client targets its own
 origin's `/api` at runtime. See [docs/environments-and-deploy.md](./docs/environments-and-deploy.md).
 
+## Test / lint / typecheck
+
+```bash
+npm test           # Vitest (unit tests)
+npm run lint       # ESLint
+npm run typecheck  # tsc --noEmit
+```
+
 ## Requirements
 
 - Node >= 22 (client engine requirement; see `.nvmrc`).

--- a/package/zerobias/example-nextjs-v2/docs/identity-and-orgs.md
+++ b/package/zerobias/example-nextjs-v2/docs/identity-and-orgs.md
@@ -56,9 +56,10 @@ import type { Org, WhoAmI } from "@zerobias-com/dana-sdk";
   await app.selectOrg(org); // Promise<void>
   ```
 
-`OrgSwitcher` lists with `listOrgs`, renders a `<select>`, and calls `selectOrg`
-on change. Feature pages that are org-scoped (e.g. Products) re-query when
-`org.id` changes.
+`OrgSwitcher` lists with `listOrgs`, renders an accessible custom listbox (a
+WAI-ARIA `role="listbox"` — styled to match the portal, keyboard-navigable with
+arrow/Home/End/Enter/Escape), and calls `selectOrg` when a row is chosen. Feature
+pages that are org-scoped (e.g. Products) re-query when `org.id` changes.
 
 ## Sign out
 

--- a/package/zerobias/example-nextjs-v2/docs/loading-and-status.md
+++ b/package/zerobias/example-nextjs-v2/docs/loading-and-status.md
@@ -1,0 +1,84 @@
+# Loading & status UI
+
+The shared feedback components — how the app shows "the page is loading", "this
+data is loading", "this action is running", and "this resource's status". All are
+React ports of the portal's own patterns (`@zerobias-org/ngx-library` /
+`zb-ui-lib`), so the reference app looks and behaves like the platform.
+
+Two loading tiers, deliberately kept distinct:
+
+| Tier | When | Component |
+| --- | --- | --- |
+| **Page loading** | app still connecting, before any UI | `PageLoader` (the "0" mark) |
+| **In-place loading** | page is up, a specific piece of data/action is pending | `Spinner`, `TableSkeleton`, `ButtonLabel` |
+
+## Page loader — the "0" mark
+
+`src/components/PageLoader.tsx` — a port of the portal's `.app-loading` bootstrap
+indicator (`zb-ui-lib/.../components.scss`): the ZeroBias **"0"** (a slashed zero
+in the **Mitr** brand font) with a cyan bar sweeping across it via the
+`zerobiasSlide` keyframes. This is the *only* full-page loading state; it is not
+used for data loads once the page is up.
+
+- Wired into [`AuthGate`](../src/components/AuthGate.tsx): shown while the session
+  is still resolving (pre-auth). No visible label — just the branded mark — with
+  a `role="status"` + visually-hidden text for screen readers.
+- The Mitr font is loaded in [`layout.tsx`](../src/app/layout.tsx) via
+  `next/font/google` as `--font-mitr`; its slashed-zero glyph is what gives the
+  mark its look.
+- Styles + the `zerobiasSlide` animation live in `src/styles/_layout.scss`; the
+  two sweep colors are the portal's `--zb-primary` / `--zb-primary-100`.
+
+## Spinner
+
+`src/components/Spinner.tsx` — the equivalent of the portal's `mat-spinner`, for
+in-place data loads after the page is up. An indeterminate SVG arc rotating via
+the shared `zb-spin` keyframes. The arc is `currentColor`, so it inherits the
+surrounding text color; `diameter` matches `mat-spinner`'s API.
+
+- Standalone default is cyan (`--zb-primary`) — right on cards/menus.
+- Inside a button it inherits the button's text color (white on a primary `.btn`)
+  via a `.btn .spinner-svg { color: inherit }` rule, so it never vanishes on the
+  fill.
+- Used by: [`OrgSwitcher`](../src/components/OrgSwitcher.tsx) (while orgs load),
+  the Products / PKV table loading lines, and `ButtonLabel`.
+
+## Table skeleton
+
+`src/components/TableSkeleton.tsx` — pulsing placeholder `<tr>`s that hold a
+table's shape while its data loads, so the layout doesn't jump when rows arrive.
+`firstColIcon` renders the first cell as a circle (for logo/avatar columns).
+Paired with a `Spinner` "Loading…" line above the table for the active signal.
+Used by [`products`](../src/app/products/page.tsx) and [`pkv`](../src/app/pkv/page.tsx).
+
+## Button label
+
+`src/components/ButtonLabel.tsx` — a port of the portal's `zb-ui-button-label`
+(`ZbUiButtonLabelComponent`). Swaps a button's label for a `Spinner` while an
+action is in flight. Drop it in as the button's child and drive `loading` from
+the action's pending state; **keep the button's own `disabled={loading}`** so the
+spinner state also blocks repeat clicks — the reason the portal uses this instead
+of a plain text label.
+
+Used by: PKV "Save pair", "Create API Key", "Create Shared Session".
+
+## Status dots
+
+`src/components/StatusDot.tsx` — a port of ngx-library's `zb-resource-status` in
+dot mode. Renders a resource's operational status as a small colored circle:
+
+- **Solid** fill for terminal states (e.g. `up` → solid green).
+- **Outlined** ring (hollow) for transitional states (e.g. `standby` → hollow
+  green), so `up` and `standby` — both green — stay distinguishable, exactly as
+  the portal's dot does.
+- Color-only by design (the status word is wasted space next to a name); the
+  label is on hover (`title`) and exposed to assistive tech (`aria-label`).
+
+Colors are ngx-library's own `--zb-color-*` tokens, mirrored verbatim in
+`src/styles/_tokens.scss` (green `--zb-color-success`, red `--zb-color-error`,
+amber `--zb-color-warning`, blue `--zb-color-info`, grey `--zb-color-gray`), with
+text from the matching `--zb-text-on-*-bg` token. The dot geometry (14px hole,
+3px ring, `content-box`) matches ngx's `size-default` circle exactly.
+
+Used by the connection picker in the [module chain](./module-chain.md) — see
+`src/components/ConnectionPicker.tsx`.

--- a/package/zerobias/example-nextjs-v2/docs/module-chain.md
+++ b/package/zerobias/example-nextjs-v2/docs/module-chain.md
@@ -1,0 +1,72 @@
+# Module usage — the connection chain (GitHub)
+
+Demonstrated in [`src/app/module/page.tsx`](../src/app/module/page.tsx). It connects
+a real GitHub client **through the Hub** and lists an org's repositories, by
+walking the module chain:
+
+```
+product (github.github)   portalClient.getProductApi().search({ packageCode })
+  -> module               storeClient.getModuleApi().search({ products })
+    -> connection         hubClient.getConnectionApi().search({ modules })
+      -> scope            hubClient.getScopeApi().search({ connections })
+        -> hub client     new GithubHubImpl().connect(HubConnectionProfile)
+```
+
+Each discovered connection is picked from an accessible listbox
+(`src/components/ConnectionPicker.tsx`) that shows its operational status as a
+colored dot — see [loading-and-status.md](./loading-and-status.md#status-dots).
+Non-usable connections (status not `up`/`standby`) render disabled.
+
+The first four hops are read-only platform discovery. The last hop is the point:
+
+```ts
+import { GithubHubImpl } from "@auditlogic/hub-sdk-github-github";
+import { HubConnectionProfile } from "@zerobias-org/types-core-js";
+import { getZerobiasClientUrl } from "@zerobias-com/zerobias-client";
+
+const profile = new HubConnectionProfile(
+  getZerobiasClientUrl("hub", true, env.isLocalDev), // Hub server URL
+  api.toUUID(targetId),          // scope id (multi-scope) or connection id (single-scope)
+  env.isLocalDev ? env.apiKey : undefined,
+  undefined,                     // session
+  api.toUUID(org.id),            // org for multi-tenancy
+);
+const client = new GithubHubImpl();
+await client.connect(profile);
+
+const orgs = await client.getOrganizationApi().listMyOrganizations(1, 25);
+const repos = await client.getOrganizationApi().listRepositories(
+  orgName, OrganizationApi.TypeEnum.All, OrganizationApi.SortEnum.FullName,
+  OrganizationApi.DirectionEnum.Asc, 1, 25,
+);
+```
+
+**The Hub holds the connection's GitHub credentials** — the browser never sees a
+GitHub token. `HubConnectionProfile` authenticates the *Hub* call (platform
+session cookie in the browser, or the app's API key in local dev) and routes to
+the `targetId`.
+
+## The GitHub Hub SDK dependency
+
+Use **`@auditlogic/hub-sdk-github-github`** — the dedicated, lightweight Hub SDK
+for the GitHub module (v2 stack, `axios@1`). It ships clean subpath exports, so
+no deep paths: the client (`GithubHubImpl`, `OrganizationApi`) is the package
+root, and the models (`Organization`, `Repository`) are `.../github/model`. It
+needs `@zerobias-org/util-connector` (the `HubConnector` base) at runtime.
+
+> Do **not** use `@auditlogic/module-github-github-client-ts` (6.x, v1 stack —
+> `axios@0.27`, `@auditmation/*`; forces a dual-stack install + a critical vuln),
+> nor the full `@auditlogic/module-github-github` module package (bundles the
+> server impl + octokit). The Hub SDK is the browser client.
+>
+> Note: the SDK's published `peerDependencies` are stale (`^1.x`) while its real
+> runtime deps are all v2 stack, so the app sets `legacy-peer-deps=true` in
+> [`.npmrc`](../.npmrc) to let the install resolve (CI and local both need it).
+> This is being corrected upstream in `auditlogic/module`; the flag can be
+> dropped once the SDK's peerDeps are fixed.
+
+## Prerequisite
+
+A GitHub **connection must already exist in the current org** (created in the
+portal). With no connection, the chain runs but lists nothing — the discovery
+hops just return empty.

--- a/package/zerobias/example-nextjs-v2/docs/shared-session-keys.md
+++ b/package/zerobias/example-nextjs-v2/docs/shared-session-keys.md
@@ -1,0 +1,35 @@
+# Shared session keys
+
+A **shared session key** lets someone else act in *your* current session until it
+expires. Treat it like a credential — whoever holds it inherits your access.
+
+Demonstrated in [`CreateSharedSessionDialog`](../src/components/CreateSharedSessionDialog.tsx),
+opened from the user menu ("Share Session"), mirroring the portal.
+
+## Canonical call
+
+```ts
+import { CreateSharedSessionKeyBody } from "@zerobias-com/dana-sdk";
+import { Duration } from "@zerobias-org/types-core-js";
+
+// principalId omitted -> current user; expiration is an ISO-8601 Duration.
+const body = new CreateSharedSessionKeyBody(undefined, new Duration("PT60M"));
+const shared = await api.danaClient.getMeApi().createSharedSessionKey(body);
+// shared.key         -> the key to hand off (returned only here)
+// shared.expiration  -> DateTime the key stops working
+```
+
+List existing keys: `api.danaClient.getMeApi().listSharedSessionKeys()`.
+
+## Two details worth copying
+
+- **`expiration` is a `Duration`, not a timestamp.** It's ISO-8601 (`PT<minutes>M`,
+  e.g. `PT60M` = 60 minutes) — build it with `new Duration(...)`, don't pass a date.
+- **`key` is returned once, at creation** (like an API key's secret). It can't be
+  fetched again, so surface it immediately for copying.
+
+## Shape
+
+`CreateSharedSessionKeyBody(principalId?: UUID, expiration?: Duration)`
+
+`SharedSessionKey { id, sessionId, key: string, expiration: DateTime, orgId?, sharedSessionIds? }`

--- a/package/zerobias/example-nextjs-v2/docs/theming.md
+++ b/package/zerobias/example-nextjs-v2/docs/theming.md
@@ -1,0 +1,43 @@
+# Theming (light / dark)
+
+This app themes **identically to the ZeroBias portal** — same storage, same
+class, same defaults — so it looks right both standalone and when embedded in the
+portal's iframe. It is a faithful port of the portal's `ZbThemeService`
+(`@zerobias-org/ngx-library`) into framework-neutral code.
+
+## The model (matches the portal exactly)
+
+| Concern | Value |
+|---|---|
+| localStorage key | `zb-theme-preference` |
+| Stored values | `light` \| `dark` \| `system` (default **`system`**) |
+| Dark applied via | **`dark-theme` class** on `<body>` (and `<html>` from the FOWT script) |
+| Native UI | `document.documentElement.style.colorScheme` = `dark`/`light` |
+| Light is the default | bare `:root`; `.dark-theme` is the override |
+
+Because dark is a *class*, the switch is a values-only swap — see
+[`src/styles/_tokens.scss`](../src/styles/_tokens.scss): light values live in
+`:root`, dark overrides under `html.dark-theme, body.dark-theme`.
+
+## Standalone vs. embedded
+
+- **Standalone** (top-level window): resolves its own preference and, while the
+  preference is `system`, follows the OS `prefers-color-scheme` and reacts to
+  changes live.
+- **Embedded in the portal iframe**: does **not** self-apply on load. It listens
+  for the portal's `theme_change` `postMessage` and follows the portal's theme.
+  This is the whole point of matching the model — a bespoke toggle would drift
+  from the portal when embedded.
+
+## Where it lives
+
+| Piece | File |
+|---|---|
+| Controller + `useTheme()` hook | [`src/lib/theme.ts`](../src/lib/theme.ts) |
+| Light/dark token values | [`src/styles/_tokens.scss`](../src/styles/_tokens.scss) |
+| Flash-of-wrong-theme prevention (pre-paint script) | [`src/app/layout.tsx`](../src/app/layout.tsx) |
+| Toggle UI | [`src/components/UserMenu.tsx`](../src/components/UserMenu.tsx) |
+
+The `UserMenu` toggle is a two-state flip (`toggle()`), matching the portal's
+user menu. The controller also exposes a three-state `cycle()`
+(`system -> light -> dark`) if you want a tri-state control.

--- a/package/zerobias/example-nextjs-v2/package-lock.json
+++ b/package/zerobias/example-nextjs-v2/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "example-nextjs-v2",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "example-nextjs-v2",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
+        "@auditlogic/hub-sdk-github-github": "^7.1.6",
         "@zerobias-com/dana-sdk": "^2.0.4",
         "@zerobias-com/portal-sdk": "^2.0.2",
         "@zerobias-com/zerobias-client": "^2.0.5",
         "@zerobias-org/types-core-js": "^2.0.3",
+        "@zerobias-org/util-connector": "^2.0.2",
         "axios": "^1.16.0",
         "material-symbols": "^0.31.9",
         "next": "^16.2.10",
@@ -27,11 +29,22 @@
         "eslint": "^9",
         "eslint-config-next": "^16.2.10",
         "sass": "^1.101.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^3.2.7"
       },
       "engines": {
         "node": ">=22.0.0",
         "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@auditlogic/hub-sdk-github-github": {
+      "version": "7.1.6",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/hub-sdk-github-github/-/b51df2577254f9abc2612055cb3098a9808c369d",
+      "integrity": "sha512-fyrKRIQ0+u0dvzRrfv0vGa2ijG6UK163YrtYJ4YgOxtRiScIWrFI05f4vofWDhF7+W9f6D1dKkNvNHyTrQMiGQ==",
+      "peerDependencies": {
+        "@zerobias-org/types-core-js": "^1.2.19",
+        "@zerobias-org/util-connector": "^1.0.32",
+        "axios": "^1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -294,6 +307,26 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -325,6 +358,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1621,12 +2096,372 @@
         "node": ">=14"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -1647,6 +2482,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1698,6 +2551,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.63.0",
@@ -2305,6 +3164,121 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@zerobias-com/cardservice-sdk": {
       "version": "2.0.10",
       "resolved": "https://pkg.zerobias.org/@zerobias-com/cardservice-sdk/-/4e054b5bd0af6d3708b81ead8d5deebe677be14e",
@@ -2722,6 +3696,22 @@
         "npm": ">=10.0.0"
       }
     },
+    "node_modules/@zerobias-org/logger": {
+      "version": "4.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/logger/-/logger-4.0.0.tgz",
+      "integrity": "sha512-FjJMbNFkFIpONIUcOdevDu/ihDFcymtfsSJy9ew3gBQXGbw9Z3kYW6hpxBji/AsZAHZ/uXRk/Ese82L+wnJtyw==",
+      "license": "ISC",
+      "dependencies": {
+        "@zerobias-org/util-api-client-base": "^2.0.0",
+        "chalk": "^5.6.2",
+        "winston": "^3.2.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
     "node_modules/@zerobias-org/types-core": {
       "version": "2.0.1",
       "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core/-/types-core-2.0.1.tgz",
@@ -2785,6 +3775,21 @@
         "axios": "^1.16.0",
         "form-data": "^4.0.0",
         "qs": "^6.14.0"
+      }
+    },
+    "node_modules/@zerobias-org/util-connector": {
+      "version": "2.0.2",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/util-connector/-/util-connector-2.0.2.tgz",
+      "integrity": "sha512-8ryGtPp+D5tx3oATXjbicxljWquolYGyDlRaKoNIV7CAdjZNvZlNdEZQwshrB9Kk3GbTYSelr8UC7oLzNOcsoQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@zerobias-org/logger": "^4.0.0",
+        "@zerobias-org/types-core-js": "^2.0.1",
+        "axios": "^1.16.0"
+      },
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/abbrev": {
@@ -2861,15 +3866,12 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -3052,11 +4054,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
     "node_modules/async-function": {
@@ -3213,6 +4231,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -3291,28 +4319,50 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^5.0.0"
@@ -3330,23 +4380,51 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
       "license": "MIT",
       "dependencies": {
-        "color-name": "~1.1.4"
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
       },
       "engines": {
-        "node": ">=7.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3504,6 +4582,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3654,6 +4742,12 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
     "node_modules/es-abstract": {
       "version": "1.24.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
@@ -3788,6 +4882,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -3847,6 +4948,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -4234,6 +5377,59 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -4288,6 +5484,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4296,6 +5502,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4358,6 +5574,30 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -4422,6 +5662,12 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -4489,6 +5735,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -4857,7 +6118,7 @@
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
       "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -4886,6 +6147,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -5244,6 +6511,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -5523,6 +6802,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -5580,6 +6865,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5592,6 +6894,13 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -5610,6 +6919,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/material-symbols": {
@@ -5842,9 +7161,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5986,6 +7305,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/optionator": {
@@ -6150,6 +7478,23 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6329,11 +7674,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -6442,6 +7801,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6495,6 +7899,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6543,7 +7967,7 @@
       "version": "1.101.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
       "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -6765,6 +8189,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6793,6 +8224,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -6805,6 +8259,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -7040,6 +8503,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -7089,6 +8572,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -7106,24 +8609,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
@@ -7137,6 +8622,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7148,6 +8663,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7429,6 +8953,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
@@ -7440,6 +8970,232 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vuln-vects": {
@@ -7552,6 +9308,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7606,6 +9415,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -7636,18 +9478,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/yallist": {

--- a/package/zerobias/example-nextjs-v2/package.json
+++ b/package/zerobias/example-nextjs-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-nextjs-v2",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "ZeroBias v2 client + SDK example app (Next.js). Canonical patterns for building a custom app on the ZeroBias platform.",
   "scripts": {
@@ -8,13 +8,17 @@
     "build": "next build --webpack",
     "preview": "npx serve dist",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "@auditlogic/hub-sdk-github-github": "^7.1.6",
     "@zerobias-com/dana-sdk": "^2.0.4",
     "@zerobias-com/portal-sdk": "^2.0.2",
     "@zerobias-com/zerobias-client": "^2.0.5",
     "@zerobias-org/types-core-js": "^2.0.3",
+    "@zerobias-org/util-connector": "^2.0.2",
     "axios": "^1.16.0",
     "material-symbols": "^0.31.9",
     "next": "^16.2.10",
@@ -30,7 +34,8 @@
     "eslint": "^9",
     "eslint-config-next": "^16.2.10",
     "sass": "^1.101.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.7"
   },
   "engines": {
     "node": ">=22.0.0",

--- a/package/zerobias/example-nextjs-v2/src/app/layout.tsx
+++ b/package/zerobias/example-nextjs-v2/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Roboto } from "next/font/google";
+import { Roboto, Mitr } from "next/font/google";
 import "material-symbols/outlined.css";
 import "@/styles/main.scss";
 import { SessionProvider } from "@/context/session-context";
@@ -12,20 +12,70 @@ const roboto = Roboto({
   variable: "--font-roboto",
 });
 
+// Mitr — the portal's brand font for the "0" page loader. Its zero glyph is
+// slashed, which is what gives the ZeroBias loading mark its look (see the
+// `.app-loading` port in _layout.scss). Only used by the page loader.
+const mitr = Mitr({
+  subsets: ["latin"],
+  weight: ["400"],
+  variable: "--font-mitr",
+});
+
 export const metadata: Metadata = {
   title: "ZeroBias v2 Example",
   description:
     "Canonical example of building a custom app on the ZeroBias platform with the v2 client + SDKs.",
 };
 
+// FOWT (Flash of Wrong Theme) prevention — a port of the portal's `index.html`
+// bootstrap. Runs before first paint: resolves `zb-theme-preference` (falling
+// back to the OS setting) and adds the `dark-theme` class + `color-scheme`
+// before React hydrates, so there is no light->dark flash. The runtime
+// controller (src/lib/theme.ts) takes over from here.
+const FOWT_SCRIPT = `(function(){
+  var STORAGE_KEY='zb-theme-preference',DARK_CLASS='dark-theme';
+  try{
+    var pref=localStorage.getItem(STORAGE_KEY);
+    var isDark=pref==='dark'?true:pref==='light'?false:(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);
+    if(isDark){
+      document.documentElement.classList.add(DARK_CLASS);
+      document.addEventListener('DOMContentLoaded',function(){document.body.classList.add(DARK_CLASS);});
+    }
+    document.documentElement.style.colorScheme=isDark?'dark':'light';
+  }catch(e){}
+})();`;
+
+/**
+ * Root layout = the app's composition root. The nesting order is the pattern to copy:
+ *   SessionProvider  -> boots the v2 client once and exposes session state; outermost
+ *                       so every route/component below can call `useSession()`.
+ *   AuthGate         -> blocks all app UI until an authenticated user resolves (or the
+ *                       client has already redirected to platform SSO).
+ *   Header + <main>  -> only ever render for an authenticated user.
+ *
+ * Intentionally NOT a `"use client"` component: the root layout stays a Server Component
+ * so `metadata` is emitted at build time. The client boundary starts inside SessionProvider.
+ */
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={roboto.variable}>
-      <body>
+    // suppressHydrationWarning: the FOWT script adds `dark-theme` + `color-scheme`
+    // to <html>/<body> before React hydrates, so their attributes intentionally
+    // differ from the server HTML. This suppresses only these two elements' own
+    // attribute diff (one level deep), not their children.
+    <html
+      lang="en"
+      className={`${roboto.variable} ${mitr.variable}`}
+      suppressHydrationWarning
+    >
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: FOWT_SCRIPT }} />
+        <style>{`body{background:#fafafa}html.dark-theme body,body.dark-theme{background:#303030}`}</style>
+      </head>
+      <body suppressHydrationWarning>
         <SessionProvider>
           <AuthGate>
             <Header />

--- a/package/zerobias/example-nextjs-v2/src/app/module/page.tsx
+++ b/package/zerobias/example-nextjs-v2/src/app/module/page.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ProductExtended } from "@zerobias-com/portal-sdk";
+import { HubConnectionProfile } from "@zerobias-org/types-core-js";
+// The GitHub Hub SDK — the dedicated browser client for the GitHub module.
+// `GithubHubImpl` extends the v2 HubConnector (same role as v1's `newGithub()`
+// client, on the v2 stack). Runtime API from the package root; model types from
+// its `/model` subpath export.
+import { GithubHubImpl, OrganizationApi } from "@auditlogic/hub-sdk-github-github";
+import type {
+  Organization,
+  Repository,
+} from "@auditlogic/hub-sdk-github-github/model";
+import { getZerobiasClientUrl } from "@zerobias-com/zerobias-client";
+import { useSession } from "@/context/session-context";
+import { env } from "@/lib/env";
+import { toUserMessage } from "@/lib/errors";
+import {
+  ConnectionPicker,
+  type ConnectionOption,
+} from "@/components/ConnectionPicker";
+
+// GitHub's product package code in the catalog — the entry point of the chain.
+const GITHUB_PACKAGE_CODE = "github.github";
+
+function statusValue(status: unknown): string | undefined {
+  return typeof status === "string"
+    ? status
+    : (status as { value?: string })?.value;
+}
+
+// A connection/scope is only usable when its operational status is up or standby.
+function isUsable(status: unknown): boolean {
+  const v = statusValue(status);
+  return v === "up" || v === "standby";
+}
+
+/**
+ * Module Usage — the canonical "module chain":
+ *
+ *   product (github.github)     portalClient.getProductApi().search()
+ *     -> module                 storeClient.getModuleApi().search({ products })
+ *       -> connection           hubClient.getConnectionApi().search({ modules })
+ *         -> scope              hubClient.getScopeApi().search({ connections })
+ *           -> hub module client  new GithubHubImpl().connect(HubConnectionProfile)
+ *
+ * The first four hops are read-only platform discovery. The last hop builds a
+ * `HubConnectionProfile(server, targetId, apiKey?, session?, orgId?)` and connects
+ * a real GitHub client THROUGH the Hub — the Hub holds the connection's GitHub
+ * credentials, so the browser never sees them. `targetId` is the scope id for a
+ * multi-scope connection, or the connection id for a single-scope one.
+ *
+ * Requires a GitHub connection to already exist in the current org (created in the
+ * portal). With no connection, the chain simply lists nothing.
+ */
+export default function ModulePage() {
+  const { api, org, ready } = useSession();
+
+  const [product, setProduct] = useState<ProductExtended | null>(null);
+  const [connections, setConnections] = useState<ConnectionOption[]>([]);
+  const [connectionId, setConnectionId] = useState("");
+  const [scopes, setScopes] = useState<ScopeRow[]>([]);
+  const [scopeId, setScopeId] = useState("");
+  const [orgs, setOrgs] = useState<Organization[]>([]);
+  const [orgName, setOrgName] = useState("");
+  const [repos, setRepos] = useState<Repository[]>([]);
+
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Monotonic run id, bumped on every user selection. Async results only apply
+  // if their run is still the current one — so a slow response from a superseded
+  // selection can't overwrite the current one (this is what fixes the race).
+  const runIdRef = useRef(0);
+  const isCurrent = (id: number) => runIdRef.current === id;
+  // One connected client per target (connection/scope), reused across list calls
+  // instead of reconnecting every time (reconnecting could race the Hub session).
+  const clientsRef = useRef(new Map<string, GithubHubImpl>());
+  // Debounce the connect step so rapidly flipping selections fires just one connect.
+  const connectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Invalidate all in-flight work + clear the timer on unmount.
+  useEffect(
+    () => () => {
+      runIdRef.current++;
+      if (connectTimerRef.current) clearTimeout(connectTimerRef.current);
+    },
+    [],
+  );
+
+  // ---- Hop 1+2+3: product -> module -> connection ------------------------
+  const loadConnections = useCallback(async () => {
+    if (!api) return;
+    const runId = ++runIdRef.current;
+    clientsRef.current.clear(); // org may have changed — drop cached clients
+    setConnectionId("");
+    setScopes([]);
+    setScopeId("");
+    setOrgs([]);
+    setOrgName("");
+    setRepos([]);
+    setBusy("Finding GitHub connections…");
+    setError(null);
+    try {
+      // Hop 1 — the GitHub product.
+      const products = await api.portalClient
+        .getProductApi()
+        .search({ packageCode: GITHUB_PACKAGE_CODE }, 1, 1);
+      if (!isCurrent(runId)) return;
+      const githubProduct = products.items[0];
+      setProduct(githubProduct ?? null);
+      if (!githubProduct) {
+        setError("GitHub product not found in the catalog.");
+        return;
+      }
+
+      // Hop 2 — modules implementing that product (computed, not shown — as in v1).
+      const modules = await api.storeClient
+        .getModuleApi()
+        .search({ products: [githubProduct.id] }, 1, 50);
+      if (!isCurrent(runId)) return;
+      const moduleIds = modules.items.map((m) => m.id);
+      if (moduleIds.length === 0) {
+        setError("No modules implement the GitHub product.");
+        return;
+      }
+
+      // Hop 3 — connections using those modules.
+      const conns = await api.hubClient
+        .getConnectionApi()
+        .search({ modules: moduleIds }, 1, 50);
+      if (!isCurrent(runId)) return;
+      setConnections(
+        conns.items.map((c) => ({
+          id: c.id.toString(),
+          name: c.name,
+          // Raw operational status (e.g. "up") — the StatusDot maps it to a
+          // color + solid/outlined dot, so keep the raw value here, not a
+          // pre-formatted string.
+          status: statusValue(c.status) ?? "unknown",
+          usable: isUsable(c.status),
+        })),
+      );
+    } catch (err) {
+      if (!isCurrent(runId)) return;
+      console.error("Failed to load GitHub connections", err);
+      setError(toUserMessage(err));
+    } finally {
+      if (isCurrent(runId)) setBusy(null);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    if (!ready || !api) return;
+    // Defer off the synchronous effect phase — loadConnections sets state.
+    const t = setTimeout(() => void loadConnections(), 0);
+    return () => clearTimeout(t);
+  }, [ready, api, loadConnections, org?.id]);
+
+  // Debounced connect: only the last selection within the window fires a connect.
+  const scheduleConnect = (targetId: string, runId: number) => {
+    if (connectTimerRef.current) clearTimeout(connectTimerRef.current);
+    connectTimerRef.current = setTimeout(() => {
+      if (isCurrent(runId)) void connectAndListOrgs(targetId, runId);
+    }, 300);
+  };
+
+  // ---- Hop 4: connection -> scope ---------------------------------------
+  const chooseConnection = async (id: string) => {
+    const runId = ++runIdRef.current; // supersede any in-flight work
+    setConnectionId(id);
+    setScopeId("");
+    setScopes([]);
+    setOrgs([]);
+    setOrgName("");
+    setRepos([]);
+    setError(null);
+    if (!api || !id) return;
+    setBusy("Loading scopes…");
+    try {
+      const results = await api.hubClient
+        .getScopeApi()
+        .search({ connections: [api.toUUID(id)] }, 1, 50);
+      if (!isCurrent(runId)) return;
+      const rows: ScopeRow[] = results.items
+        .map((s) => ({
+          id: s.id.toString(),
+          name: s.name,
+          usable: isUsable(s.status),
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      setScopes(rows);
+      // Single scope -> use it directly; connect against the connection id.
+      if (rows.length <= 1) {
+        scheduleConnect(rows.length === 1 ? rows[0].id : id, runId);
+      }
+    } catch (err) {
+      if (!isCurrent(runId)) return;
+      console.error("Failed to load scopes", err);
+      setError(toUserMessage(err));
+    } finally {
+      if (isCurrent(runId)) setBusy(null);
+    }
+  };
+
+  const chooseScope = (id: string) => {
+    const runId = ++runIdRef.current;
+    setScopeId(id);
+    setOrgs([]);
+    setOrgName("");
+    setRepos([]);
+    setError(null);
+    if (id) scheduleConnect(id, runId);
+  };
+
+  // ---- Hop 5: connect the GitHub Hub client (cached), list orgs ---------
+  const connectClient = async (targetId: string): Promise<GithubHubImpl> => {
+    const cached = clientsRef.current.get(targetId);
+    if (cached) return cached; // reuse — don't reconnect for every list call
+    // The Hub routes to the target connection/scope; it injects the stored
+    // GitHub credentials server-side. In local dev we authenticate the Hub call
+    // with the app's API key; in the browser session the platform cookie is used.
+    const profile = new HubConnectionProfile(
+      getZerobiasClientUrl("hub", true, env.isLocalDev),
+      api!.toUUID(targetId),
+      env.isLocalDev ? env.apiKey : undefined,
+      undefined,
+      org ? api!.toUUID(org.id) : undefined,
+    );
+    const client = new GithubHubImpl();
+    await client.connect(profile);
+    clientsRef.current.set(targetId, client); // cache only after a successful connect
+    return client;
+  };
+
+  const connectAndListOrgs = async (targetId: string, runId: number) => {
+    if (!api) return;
+    setBusy("Connecting to GitHub via the Hub…");
+    setError(null);
+    try {
+      const client = await connectClient(targetId);
+      if (!isCurrent(runId)) return;
+      const result = await client.getOrganizationApi().listMyOrganizations(1, 25);
+      if (!isCurrent(runId)) return;
+      setOrgs(result.items);
+    } catch (err) {
+      if (!isCurrent(runId)) return;
+      console.error("Failed to list GitHub organizations", err);
+      setError(toUserMessage(err));
+    } finally {
+      if (isCurrent(runId)) setBusy(null);
+    }
+  };
+
+  // ---- Repositories for the chosen GitHub org ---------------------------
+  const chooseOrg = async (name: string) => {
+    const runId = ++runIdRef.current;
+    setOrgName(name);
+    setRepos([]);
+    setError(null);
+    if (!api || !name) return;
+    // Active target (scope if chosen, else connection) — reuses the cached client.
+    const targetId = scopeId || connectionId;
+    setBusy("Loading repositories…");
+    try {
+      const client = await connectClient(targetId);
+      if (!isCurrent(runId)) return;
+      const result = await client
+        .getOrganizationApi()
+        .listRepositories(
+          name,
+          OrganizationApi.TypeEnum.All,
+          OrganizationApi.SortEnum.FullName,
+          OrganizationApi.DirectionEnum.Asc,
+          1,
+          25,
+        );
+      if (!isCurrent(runId)) return;
+      setRepos(result.items);
+    } catch (err) {
+      if (!isCurrent(runId)) return;
+      console.error("Failed to list repositories", err);
+      setError(toUserMessage(err));
+    } finally {
+      if (isCurrent(runId)) setBusy(null);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Module Usage — GitHub</h1>
+      <p className="subtitle">
+        The module chain: <code>product → module → connection → scope → hub
+        client</code>. Pick a GitHub connection to list an org&apos;s
+        repositories through the Hub.
+      </p>
+
+      {error && (
+        <p className="state error" role="alert">
+          Error: {error}
+        </p>
+      )}
+
+      <div className="form-card">
+        <div className="field">
+          <label>Product</label>
+          <input value={product?.name ?? "GitHub"} readOnly />
+        </div>
+
+        <div className="field">
+          <label htmlFor="mc-connection">Connection ({connections.length})</label>
+          <ConnectionPicker
+            id="mc-connection"
+            connections={connections}
+            value={connectionId}
+            onChange={chooseConnection}
+            disabled={connections.length === 0}
+          />
+        </div>
+
+        {scopes.length > 1 && (
+          <div className="field">
+            <label htmlFor="mc-scope">Scope ({scopes.length})</label>
+            <select
+              id="mc-scope"
+              value={scopeId}
+              onChange={(e) => chooseScope(e.target.value)}
+            >
+              <option value="">Select a scope</option>
+              {scopes.map((s) => (
+                <option key={s.id} value={s.id} disabled={!s.usable}>
+                  {s.name}
+                  {s.usable ? "" : " (unavailable)"}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {orgs.length > 0 && (
+          <div className="field">
+            <label htmlFor="mc-org">GitHub Org ({orgs.length})</label>
+            <select
+              id="mc-org"
+              value={orgName}
+              onChange={(e) => chooseOrg(e.target.value)}
+            >
+              <option value="">Select a GitHub org</option>
+              {orgs.map((o) => (
+                <option key={o.id} value={o.name}>
+                  {o.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      {busy && <p className="state">{busy}</p>}
+
+      <h2>Repositories {repos.length > 0 ? `(${repos.length})` : ""}</h2>
+      {repos.length === 0 ? (
+        <p className="state">
+          {orgName ? "No repositories." : "Pick a connection and GitHub org above."}
+        </p>
+      ) : (
+        <div className="table-scroll">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th>Default Branch</th>
+              </tr>
+            </thead>
+            <tbody>
+              {repos.map((r) => (
+                <tr key={r.id}>
+                  <td>
+                    <code>{r.name}</code>
+                  </td>
+                  <td>{r.description ?? "—"}</td>
+                  <td>{r.defaultBranch ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+type ScopeRow = { id: string; name: string; usable: boolean };

--- a/package/zerobias/example-nextjs-v2/src/app/page.tsx
+++ b/package/zerobias/example-nextjs-v2/src/app/page.tsx
@@ -30,6 +30,12 @@ const DEMOS = [
     body: "Read and write per-principal key-value pairs.",
     call: "danaClient.getPkvApi().upsertPrincipalKeyValue()",
   },
+  {
+    href: "/module",
+    title: "Module Usage — GitHub",
+    body: "Product → module → connection → scope → Hub client; list an org's repos.",
+    call: "new GithubHubImpl().connect(HubConnectionProfile)",
+  },
 ];
 
 export default function Home() {

--- a/package/zerobias/example-nextjs-v2/src/app/pkv/page.tsx
+++ b/package/zerobias/example-nextjs-v2/src/app/pkv/page.tsx
@@ -3,6 +3,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { Pkv } from "@zerobias-com/dana-sdk";
 import { useSession } from "@/context/session-context";
+import { toUserMessage } from "@/lib/errors";
+import { Spinner } from "@/components/Spinner";
+import { TableSkeleton } from "@/components/TableSkeleton";
+import { ButtonLabel } from "@/components/ButtonLabel";
 
 /**
  * Canonical read + write against the Principal Key-Value store.
@@ -27,9 +31,10 @@ export default function PkvPage() {
       .getPkvApi()
       .listPrincipalKeyValues(undefined, undefined, 50)
       .then((results) => setPairs(results.items))
-      .catch((err) =>
-        setError(err instanceof Error ? err.message : String(err)),
-      )
+      .catch((err) => {
+        console.error("Failed to list key-value pairs", err);
+        setError(toUserMessage(err));
+      })
       .finally(() => setLoading(false));
   }, [api]);
 
@@ -58,7 +63,8 @@ export default function PkvPage() {
       setValue('{ "example": true }');
       await load();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      console.error("Failed to save key-value pair", err);
+      setError(toUserMessage(err));
     } finally {
       setSaving(false);
     }
@@ -99,16 +105,23 @@ export default function PkvPage() {
             rows={3}
           />
         </div>
-        {error && <p className="error">{error}</p>}
+        {error && (
+          <p className="error" role="alert">
+            {error}
+          </p>
+        )}
         <button className="btn" disabled={saving || !key.trim()}>
-          {saving ? "Saving…" : "Save pair"}
+          <ButtonLabel label="Save pair" loading={saving} />
         </button>
       </form>
 
       <h2>Stored pairs</h2>
-      {loading ? (
-        <p className="state">Loading…</p>
-      ) : pairs.length === 0 ? (
+      {loading && (
+        <p className="state loading-line">
+          <Spinner diameter={18} /> Loading key-value pairs…
+        </p>
+      )}
+      {!loading && pairs.length === 0 ? (
         <p className="state">No key-value pairs yet.</p>
       ) : (
         <div className="table-scroll">
@@ -120,16 +133,20 @@ export default function PkvPage() {
               </tr>
             </thead>
             <tbody>
-              {pairs.map((p) => (
-                <tr key={p.key}>
-                  <td>
-                    <code>{p.key}</code>
-                  </td>
-                  <td>
-                    <code>{JSON.stringify(p.value)}</code>
-                  </td>
-                </tr>
-              ))}
+              {loading ? (
+                <TableSkeleton rows={5} columns={2} />
+              ) : (
+                pairs.map((p) => (
+                  <tr key={p.key}>
+                    <td>
+                      <code>{p.key}</code>
+                    </td>
+                    <td>
+                      <code>{JSON.stringify(p.value)}</code>
+                    </td>
+                  </tr>
+                ))
+              )}
             </tbody>
           </table>
         </div>

--- a/package/zerobias/example-nextjs-v2/src/app/products/page.tsx
+++ b/package/zerobias/example-nextjs-v2/src/app/products/page.tsx
@@ -4,6 +4,9 @@ import { useCallback, useEffect, useState } from "react";
 import Image from "next/image";
 import type { ProductExtended } from "@zerobias-com/portal-sdk";
 import { useSession } from "@/context/session-context";
+import { toUserMessage } from "@/lib/errors";
+import { Spinner } from "@/components/Spinner";
+import { TableSkeleton } from "@/components/TableSkeleton";
 
 const PAGE_SIZE = 10;
 
@@ -29,7 +32,8 @@ export default function ProductsPage() {
           setError(null);
         })
         .catch((err) => {
-          setError(err instanceof Error ? err.message : String(err));
+          console.error("Products search failed", err);
+          setError(toUserMessage(err));
           setProducts([]);
         })
         .finally(() => setLoading(false));
@@ -53,7 +57,17 @@ export default function ProductsPage() {
         <code>portalClient.getProductApi().search(&#123;&#125;, page, size)</code>
       </p>
 
-      {error && <p className="state error">Error: {error}</p>}
+      {error && (
+        <p className="state error" role="alert">
+          Error: {error}
+        </p>
+      )}
+
+      {loading && (
+        <p className="state loading-line">
+          <Spinner diameter={18} /> Loading products…
+        </p>
+      )}
 
       <div className="table-scroll">
         <table className="table">
@@ -68,11 +82,7 @@ export default function ProductsPage() {
           </thead>
           <tbody>
             {loading ? (
-              <tr>
-                <td colSpan={5} className="state">
-                  Loading…
-                </td>
-              </tr>
+              <TableSkeleton rows={PAGE_SIZE} columns={5} firstColIcon />
             ) : products.length === 0 ? (
               <tr>
                 <td colSpan={5} className="state">

--- a/package/zerobias/example-nextjs-v2/src/components/AuthGate.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/AuthGate.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type ReactNode } from "react";
 import { useSession } from "@/context/session-context";
+import { PageLoader } from "@/components/PageLoader";
 
 /**
  * Blocks the app until we have an authenticated user.
@@ -27,16 +28,16 @@ export function AuthGate({ children }: { children: ReactNode }) {
 
   return (
     <div className="gate">
-      <div className="gate-card">
-        <div className="spinner" aria-hidden />
-        <p>Connecting to ZeroBias…</p>
-        {slow && (
-          <p className="gate-hint">
-            Still connecting. If this persists you may not have a valid session
-            (prod) or API key (local dev). Check <code>.env.development</code>.
-          </p>
-        )}
-      </div>
+      <PageLoader
+        hint={
+          slow ? (
+            <>
+              Still connecting. If this persists you may not have a valid session
+              (prod) or API key (local dev). Check <code>.env.development</code>.
+            </>
+          ) : undefined
+        }
+      />
     </div>
   );
 }

--- a/package/zerobias/example-nextjs-v2/src/components/ButtonLabel.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/ButtonLabel.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import { Spinner } from "./Spinner";
+
+/**
+ * Button label that swaps to a spinner while an action is in flight — a port of
+ * the portal's `zb-ui-button-label` (ZbUiButtonLabelComponent). Drop it in as a
+ * `<button>`'s child and drive `loading` from the action's pending state; keep
+ * the button's own `disabled={loading}` so the spinner state also blocks repeat
+ * clicks — the reason the portal uses this instead of a plain text label.
+ *
+ * The spinner is `currentColor`, so it inherits the button's text color (white
+ * on a filled primary button), matching the label it replaces.
+ */
+export function ButtonLabel({
+  label,
+  loading,
+  diameter = 20,
+}: {
+  label: ReactNode;
+  loading: boolean;
+  diameter?: number;
+}) {
+  return loading ? (
+    <Spinner diameter={diameter} label="Working" />
+  ) : (
+    <>{label}</>
+  );
+}

--- a/package/zerobias/example-nextjs-v2/src/components/ConnectionPicker.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/ConnectionPicker.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { listboxKeyAction } from "@/lib/listbox-nav";
+import { StatusDot } from "./StatusDot";
+
+export type ConnectionOption = {
+  id: string;
+  name: string;
+  status: string; // raw operational status, e.g. "up" / "down" / "standby"
+  usable: boolean;
+};
+
+/**
+ * Accessible connection picker — a WAI-ARIA collapsible listbox rather than a
+ * native `<select>`, because a native `<option>` can only hold plain text and
+ * this control shows each connection's status as a `StatusDot` (the ngx-library
+ * `zb-resource-status` dot). It mirrors `OrgSwitcher`: the trigger owns
+ * `aria-expanded`; opening moves focus into the `role="listbox"`, which tracks
+ * the highlighted row via `aria-activedescendant` and routes keys through the
+ * shared pure `listboxKeyAction` helper. Click-outside and Escape close it.
+ *
+ * Non-usable connections (status not up/standby) render `aria-disabled` and
+ * can't be selected, but stay visible so their status chip is still legible —
+ * more informative than the greyed-out disabled `<option>` this replaces.
+ */
+export function ConnectionPicker({
+  id,
+  connections,
+  value,
+  onChange,
+  disabled = false,
+}: {
+  id?: string;
+  connections: ConnectionOption[];
+  value: string;
+  onChange: (id: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const selected = connections.find((c) => c.id === value);
+
+  // Close on click outside (mirrors OrgSwitcher / the account menu).
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  // Focus moves into the listbox once it renders (a DOM side-effect).
+  useEffect(() => {
+    if (open) listRef.current?.focus();
+  }, [open]);
+
+  const openList = () => {
+    const current = connections.findIndex((c) => c.id === value);
+    setActiveIndex(current >= 0 ? current : 0);
+    setOpen(true);
+  };
+
+  const pick = (opt: ConnectionOption | undefined) => {
+    if (!opt || !opt.usable) return; // disabled / missing row — not selectable
+    setOpen(false);
+    onChange(opt.id);
+  };
+
+  const onTriggerKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (!open && (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ")) {
+      e.preventDefault();
+      openList();
+    }
+  };
+
+  const onListKeyDown = (e: KeyboardEvent<HTMLUListElement>) => {
+    const action = listboxKeyAction(e.key, activeIndex, connections.length);
+    if (action.type === "none") return;
+    // Arrows/Home/End/Enter/Space act on the list; let Tab move focus naturally.
+    if (e.key !== "Tab") e.preventDefault();
+    if (action.type === "move") setActiveIndex(action.index);
+    else if (action.type === "select") pick(connections[activeIndex]);
+    else if (action.type === "close") setOpen(false);
+  };
+
+  const optionId = (c: ConnectionOption) => `conn-opt-${c.id}`;
+  const activeConn = activeIndex >= 0 ? connections[activeIndex] : undefined;
+
+  return (
+    <div className="conn-picker" ref={rootRef}>
+      <button
+        type="button"
+        id={id}
+        className="conn-picker-trigger"
+        onClick={() => (open ? setOpen(false) : openList())}
+        onKeyDown={onTriggerKeyDown}
+        disabled={disabled || connections.length === 0}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        {selected ? (
+          <span className="conn-picker-value">
+            <StatusDot status={selected.status} />
+            <span className="ellipsis">{selected.name}</span>
+          </span>
+        ) : (
+          <span className="conn-picker-placeholder">
+            {connections.length === 0 ? "No connections" : "Select a connection"}
+          </span>
+        )}
+        <span className="material-symbols-outlined">
+          {open ? "expand_less" : "expand_more"}
+        </span>
+      </button>
+      {open && (
+        <ul
+          className="conn-picker-list"
+          role="listbox"
+          tabIndex={-1}
+          ref={listRef}
+          aria-label="Select a connection"
+          aria-activedescendant={activeConn ? optionId(activeConn) : undefined}
+          onKeyDown={onListKeyDown}
+        >
+          {connections.map((c, i) => {
+            const isSelected = c.id === value;
+            const active = i === activeIndex;
+            return (
+              <li
+                key={c.id}
+                id={optionId(c)}
+                role="option"
+                aria-selected={isSelected}
+                aria-disabled={!c.usable}
+                className={`conn-picker-item${isSelected ? " selected" : ""}${
+                  active ? " active" : ""
+                }${c.usable ? "" : " disabled"}`}
+                onMouseEnter={() => setActiveIndex(i)}
+                onClick={() => pick(c)}
+              >
+                <StatusDot status={c.status} />
+                <span className="ellipsis">{c.name}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/package/zerobias/example-nextjs-v2/src/components/CreateApiKeyDialog.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/CreateApiKeyDialog.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import { ApiKeyWithData, CreateApiKeyBody } from "@zerobias-com/dana-sdk";
 import { DateTime } from "@zerobias-org/types-core-js";
 import { useSession } from "@/context/session-context";
+import { toUserMessage } from "@/lib/errors";
+import { ButtonLabel } from "@/components/ButtonLabel";
 
 type DurationType = "hours" | "days" | "years";
 const DURATION_TYPES: DurationType[] = ["hours", "days", "years"];
@@ -59,7 +61,8 @@ export function CreateApiKeyDialog({ onClose }: { onClose: () => void }) {
       setCreated(key);
       copy(key.data, "key");
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      console.error("Failed to create API key", err);
+      setError(toUserMessage(err));
     } finally {
       setCreating(false);
     }
@@ -171,9 +174,13 @@ export function CreateApiKeyDialog({ onClose }: { onClose: () => void }) {
               </div>
             </div>
 
-            {error && <p className="error">{error}</p>}
+            {error && (
+              <p className="error" role="alert">
+                {error}
+              </p>
+            )}
             <button className="btn" disabled={creating || !name.trim()}>
-              {creating ? "Creating…" : "Create"}
+              <ButtonLabel label="Create" loading={creating} />
             </button>
           </form>
         )}

--- a/package/zerobias/example-nextjs-v2/src/components/CreateSharedSessionDialog.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/CreateSharedSessionDialog.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { CreateSharedSessionKeyBody, SharedSessionKey } from "@zerobias-com/dana-sdk";
+import { Duration } from "@zerobias-org/types-core-js";
+import { useSession } from "@/context/session-context";
+import { toUserMessage } from "@/lib/errors";
+import { ButtonLabel } from "@/components/ButtonLabel";
+
+/**
+ * `danaClient.getMeApi().createSharedSessionKey(body)` -> `SharedSessionKey`.
+ * A shared-session key lets someone else act in YOUR current session until it
+ * expires — so treat it like a credential.
+ *
+ * Two SDK details worth copying:
+ *  - `expiration` on the request body is an **ISO-8601 Duration** (`PT<minutes>M`),
+ *    not a timestamp — build it with `new Duration("PT60M")`.
+ *  - `SharedSessionKey.key` is returned **only here, at creation** (like an API
+ *    key's secret). Surface it immediately; it can't be fetched again.
+ *
+ * Mirrors the portal's "Share Session" dialog.
+ */
+export function CreateSharedSessionDialog({ onClose }: { onClose: () => void }) {
+  const { api } = useSession();
+  const [minutes, setMinutes] = useState("60");
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [created, setCreated] = useState<SharedSessionKey | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const copy = (text: string) => {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  const submit = async () => {
+    if (!api) return;
+    const mins = parseInt(minutes, 10);
+    if (!Number.isFinite(mins) || mins < 1) {
+      setError("Expiration must be at least 1 minute.");
+      return;
+    }
+    setError(null);
+    setCreating(true);
+    try {
+      // principalId omitted -> defaults to the current user; expiration is a Duration.
+      const body = new CreateSharedSessionKeyBody(undefined, new Duration(`PT${mins}M`));
+      const shared = await api.danaClient.getMeApi().createSharedSessionKey(body);
+      setCreated(shared);
+      copy(shared.key);
+    } catch (err) {
+      console.error("Failed to create shared session key", err);
+      setError(toUserMessage(err));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onMouseDown={onClose}>
+      <div className="modal" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="modal-head">
+          <h2>{created ? "Shared Session Key" : "Share Session"}</h2>
+          <button className="modal-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        {created ? (
+          <div>
+            <p className="subtitle">
+              Copy the key now — it won&apos;t be shown again. It has also been
+              copied to your clipboard. Expires{" "}
+              {created.expiration.toString()}.
+            </p>
+
+            <div className="field">
+              <label htmlFor="shared-key">Session Key</label>
+              <div className="copy-field">
+                <input id="shared-key" value={created.key} readOnly />
+                <button
+                  type="button"
+                  className="copy-btn"
+                  onClick={() => copy(created.key)}
+                  aria-label="Copy session key"
+                >
+                  <span className="material-symbols-outlined">content_copy</span>
+                </button>
+              </div>
+              {copied && <span className="copied">Copied</span>}
+            </div>
+
+            <button className="btn" onClick={onClose}>
+              Close
+            </button>
+          </div>
+        ) : (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              void submit();
+            }}
+          >
+            <p className="subtitle">
+              Creates a temporary key that lets someone act in your current
+              session until it expires. Anyone with the key inherits your access
+              — share it carefully.
+            </p>
+
+            <div className="field">
+              <label htmlFor="share-minutes">Expires in (minutes)</label>
+              <input
+                id="share-minutes"
+                type="number"
+                min={1}
+                value={minutes}
+                onChange={(e) => setMinutes(e.target.value)}
+                autoComplete="off"
+                autoFocus
+              />
+            </div>
+
+            {error && (
+              <p className="error" role="alert">
+                {error}
+              </p>
+            )}
+            <button className="btn" disabled={creating}>
+              <ButtonLabel label="Create" loading={creating} />
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/package/zerobias/example-nextjs-v2/src/components/Header.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/Header.tsx
@@ -8,6 +8,7 @@ const NAV = [
   { href: "/", label: "Home" },
   { href: "/products", label: "Products" },
   { href: "/pkv", label: "Key-Value" },
+  { href: "/module", label: "Module" },
 ];
 
 export function Header() {

--- a/package/zerobias/example-nextjs-v2/src/components/OrgSwitcher.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/OrgSwitcher.tsx
@@ -1,19 +1,32 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import type { Org } from "@zerobias-com/dana-sdk";
 import { useSession } from "@/context/session-context";
+import { listboxKeyAction } from "@/lib/listbox-nav";
+import { Spinner } from "@/components/Spinner";
 
 /**
  * List:   `danaClient.getOrgApi().listOrgs(page, size)` -> PagedResults<Org>.
  * Switch: `app.selectOrg(org)` via `useSession().selectOrg`.
  *
  * `listOrgs` has no sort parameter, so the list is sorted by name on the client.
+ *
+ * Accessibility — a WAI-ARIA collapsible listbox (not a native `<select>`, so it
+ * can be styled to match the portal). The trigger owns `aria-expanded`; when open,
+ * focus moves into the `role="listbox"`, which tracks the highlighted row with
+ * `aria-activedescendant` and routes arrow/Home/End/Enter/Escape through the pure
+ * `listboxKeyAction` helper (see src/lib/listbox-nav.ts). Click-outside and Escape
+ * both close it. Hover and keyboard share one `activeIndex` so they stay in sync.
  */
 export function OrgSwitcher({ onSwitched }: { onSwitched?: () => void }) {
   const { api, org, selectOrg } = useSession();
   const [orgs, setOrgs] = useState<Org[]>([]);
+  const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
     if (!api) return;
@@ -31,11 +44,39 @@ export function OrgSwitcher({ onSwitched }: { onSwitched?: () => void }) {
         );
         setOrgs(sorted);
       })
-      .catch((err) => console.error("listOrgs failed", err));
+      .catch((err) => console.error("listOrgs failed", err))
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
     return () => {
       mounted = false;
     };
   }, [api]);
+
+  // Close on click outside (mirrors the account menu).
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  // Focus moves into the listbox once it renders. Focus is a DOM side-effect, so
+  // it belongs in an effect; the active row is seeded in `openList` (below) to
+  // avoid setting state synchronously inside an effect.
+  useEffect(() => {
+    if (open) listRef.current?.focus();
+  }, [open]);
+
+  const openList = () => {
+    const current = orgs.findIndex((o) => o.id.toString() === org?.id.toString());
+    setActiveIndex(current >= 0 ? current : 0);
+    setOpen(true);
+  };
 
   const pick = async (next: Org) => {
     setOpen(false);
@@ -43,30 +84,73 @@ export function OrgSwitcher({ onSwitched }: { onSwitched?: () => void }) {
     onSwitched?.();
   };
 
+  const onTriggerKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (!open && (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ")) {
+      e.preventDefault();
+      openList();
+    }
+  };
+
+  const onListKeyDown = (e: KeyboardEvent<HTMLUListElement>) => {
+    const action = listboxKeyAction(e.key, activeIndex, orgs.length);
+    if (action.type === "none") return;
+    // Arrows/Home/End/Enter/Space act on the list; let Tab move focus naturally.
+    if (e.key !== "Tab") e.preventDefault();
+    if (action.type === "move") setActiveIndex(action.index);
+    else if (action.type === "select") void pick(orgs[activeIndex]);
+    else if (action.type === "close") setOpen(false);
+  };
+
+  const optionId = (o: Org) => `org-opt-${o.id.toString()}`;
+  const activeOrg = activeIndex >= 0 ? orgs[activeIndex] : undefined;
+
   return (
-    <div className="org-switch">
+    <div className="org-switch" ref={rootRef}>
       <button
         type="button"
         className="org-switch-trigger"
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => (open ? setOpen(false) : openList())}
+        onKeyDown={onTriggerKeyDown}
         aria-haspopup="listbox"
         aria-expanded={open}
       >
         <span className="ellipsis">{org?.name ?? "Select organization"}</span>
-        <span className="material-symbols-outlined">
-          {open ? "expand_less" : "expand_more"}
-        </span>
+        {loading ? (
+          <Spinner diameter={16} label="Loading organizations" />
+        ) : (
+          <span className="material-symbols-outlined">
+            {open ? "expand_less" : "expand_more"}
+          </span>
+        )}
       </button>
       {open && (
-        <ul className="org-switch-list" role="listbox">
-          {orgs.map((o) => {
+        <ul
+          className="org-switch-list"
+          role="listbox"
+          tabIndex={-1}
+          ref={listRef}
+          aria-label="Select organization"
+          aria-activedescendant={activeOrg ? optionId(activeOrg) : undefined}
+          onKeyDown={onListKeyDown}
+        >
+          {loading && orgs.length === 0 && (
+            <li className="org-switch-loading" aria-hidden>
+              <Spinner diameter={16} /> Loading organizations…
+            </li>
+          )}
+          {orgs.map((o, i) => {
             const selected = o.id.toString() === org?.id.toString();
+            const active = i === activeIndex;
             return (
               <li
                 key={o.id.toString()}
+                id={optionId(o)}
                 role="option"
                 aria-selected={selected}
-                className={`org-switch-item${selected ? " selected" : ""}`}
+                className={`org-switch-item${selected ? " selected" : ""}${
+                  active ? " active" : ""
+                }`}
+                onMouseEnter={() => setActiveIndex(i)}
                 onClick={() => pick(o)}
               >
                 {o.name}

--- a/package/zerobias/example-nextjs-v2/src/components/PageLoader.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/PageLoader.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+/**
+ * Page preloader — a port of the portal's `.app-loading` bootstrap indicator
+ * (zb-ui-lib `components.scss`): the ZeroBias "0" (a slashed zero, in the Mitr
+ * brand font) with a cyan bar sweeping across it via the `zerobiasSlide`
+ * animation. This is the "the page is loading" state — shown while the app is
+ * still connecting, before any data-level UI exists. Once the page is up,
+ * individual data loads use the in-place `<Spinner>` instead.
+ *
+ * The mark itself is decorative (`aria-hidden`); the accessible loading status
+ * comes from the wrapper's `role="status"` + the visually-hidden label.
+ */
+export function PageLoader({
+  label,
+  hint,
+}: {
+  label?: string;
+  hint?: ReactNode;
+}) {
+  return (
+    <div className="page-loader" role="status" aria-live="polite">
+      <span className="app-loading" aria-hidden>
+        0
+      </span>
+      {label ? <p className="page-loader-label">{label}</p> : null}
+      {hint ? <p className="gate-hint">{hint}</p> : null}
+      <span className="sr-only">{label ?? "Loading page"}</span>
+    </div>
+  );
+}

--- a/package/zerobias/example-nextjs-v2/src/components/Spinner.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/Spinner.tsx
@@ -1,0 +1,46 @@
+/**
+ * In-place spinner — the equivalent of the portal's `mat-spinner`, for showing
+ * that a specific piece of data is loading (an org list, a table, a button
+ * action) AFTER the page itself is up. The full-page "loading" state uses the
+ * branded `<PageLoader>` instead; this is the smaller, local signal.
+ *
+ * An indeterminate circular spinner: a single arc (~70% gap) rotating via the
+ * shared `zb-spin` keyframes. The arc is `currentColor`, so it inherits the
+ * surrounding text color (e.g. white inside a primary button) — set `color` in
+ * CSS to recolor it. `diameter` matches `mat-spinner`'s API.
+ */
+export function Spinner({
+  diameter = 24,
+  className,
+  label = "Loading",
+}: {
+  diameter?: number;
+  className?: string;
+  label?: string;
+}) {
+  const stroke = Math.max(2, Math.round(diameter / 10));
+  const r = (diameter - stroke) / 2;
+  const circumference = 2 * Math.PI * r;
+  return (
+    <svg
+      className={`spinner-svg${className ? ` ${className}` : ""}`}
+      width={diameter}
+      height={diameter}
+      viewBox={`0 0 ${diameter} ${diameter}`}
+      role="status"
+      aria-label={label}
+    >
+      <circle
+        cx={diameter / 2}
+        cy={diameter / 2}
+        r={r}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={stroke}
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference * 0.7}
+      />
+    </svg>
+  );
+}

--- a/package/zerobias/example-nextjs-v2/src/components/StatusDot.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/StatusDot.tsx
@@ -1,0 +1,27 @@
+import { statusTone } from "@/lib/status-tone";
+
+/**
+ * Resource status dot — a React port of ngx-library's `zb-resource-status`
+ * component in dot mode (`showDot`, no label). The portal renders a resource's
+ * operational status as a small colored circle: a SOLID fill for terminal states
+ * and an OUTLINED (hollow) ring for transitional ones like `standby`. This
+ * reproduces that, including the solid-vs-outlined distinction — so `up` and
+ * `standby` (both green) stay visually distinct, exactly as the portal does.
+ *
+ * Color-only by design: the status word next to a connection name is wasted
+ * space, so the label is exposed on hover (`title`) and to assistive tech
+ * (`aria-label`) instead. Colors are ngx-library's `--zb-color-*` tokens.
+ *
+ * The status -> tone/outlined/label mapping is the pure `statusTone` helper.
+ */
+export function StatusDot({ status }: { status?: string }) {
+  const { tone, outlined, label } = statusTone(status);
+  return (
+    <span
+      className={`status-dot ${tone}${outlined ? " outlined" : ""}`}
+      role="img"
+      aria-label={`Status: ${label}`}
+      title={label}
+    />
+  );
+}

--- a/package/zerobias/example-nextjs-v2/src/components/TableSkeleton.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/TableSkeleton.tsx
@@ -1,0 +1,37 @@
+/**
+ * Skeleton rows for a loading `<table>` — shimmer placeholders that hold the
+ * table's shape while data loads, so the layout doesn't jump when rows arrive.
+ * Renders as `<tr>`s meant to sit directly inside a `<tbody>`. Pair it with a
+ * `<Spinner>` (e.g. in a status line above the table) for the "actively loading"
+ * signal; the skeleton is decorative and hidden from assistive tech.
+ *
+ * `firstColIcon` renders the first cell as a small circle (for tables whose
+ * leading column is a logo/avatar, like Products).
+ */
+export function TableSkeleton({
+  rows,
+  columns,
+  firstColIcon = false,
+}: {
+  rows: number;
+  columns: number;
+  firstColIcon?: boolean;
+}) {
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, r) => (
+        <tr key={r} className="skeleton-row" aria-hidden>
+          {Array.from({ length: columns }).map((_, c) => (
+            <td key={c}>
+              {firstColIcon && c === 0 ? (
+                <span className="skeleton skeleton-circle" />
+              ) : (
+                <span className="skeleton skeleton-bar" />
+              )}
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  );
+}

--- a/package/zerobias/example-nextjs-v2/src/components/UserMenu.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/UserMenu.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSession } from "@/context/session-context";
+import { useTheme } from "@/lib/theme";
 import { OrgSwitcher } from "./OrgSwitcher";
 import { CreateApiKeyDialog } from "./CreateApiKeyDialog";
+import { CreateSharedSessionDialog } from "./CreateSharedSessionDialog";
 
 function initials(name?: string): string {
   if (!name) return "?";
@@ -13,22 +15,18 @@ function initials(name?: string): string {
   return (first + last).toUpperCase() || "?";
 }
 
-type Theme = "dark" | "light";
-
+/**
+ * Account menu in the header. Presentation + local UI state only — it composes the two
+ * SDK-backed actions (`OrgSwitcher`, `CreateApiKeyDialog`) and drives the light/dark
+ * toggle through `useTheme` (the portal's `ZbThemeService` model — see src/lib/theme.ts).
+ */
 export function UserMenu() {
   const { user, org, logout } = useSession();
+  const { isDark, toggle } = useTheme();
   const [open, setOpen] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
-  const [theme, setTheme] = useState<Theme>(() =>
-    typeof window !== "undefined"
-      ? ((localStorage.getItem("zb-theme") as Theme) || "dark")
-      : "dark",
-  );
+  const [showShare, setShowShare] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    document.documentElement.dataset.theme = theme;
-  }, [theme]);
 
   useEffect(() => {
     if (!open) return;
@@ -43,15 +41,6 @@ export function UserMenu() {
       document.removeEventListener("keydown", onKey);
     };
   }, [open]);
-
-  const toggleTheme = useCallback(() => {
-    setTheme((t) => {
-      const next: Theme = t === "dark" ? "light" : "dark";
-      document.documentElement.dataset.theme = next;
-      localStorage.setItem("zb-theme", next);
-      return next;
-    });
-  }, []);
 
   return (
     <div className="user-menu" ref={ref}>
@@ -100,15 +89,24 @@ export function UserMenu() {
             <span className="menu-item-label">Create New API Key</span>
           </button>
 
-          <button className="menu-item" onClick={toggleTheme}>
-            <span className="material-symbols-outlined">
-              {theme === "dark" ? "dark_mode" : "light_mode"}
-            </span>
-            <span className="menu-item-label">
-              {theme === "dark" ? "Dark Theme" : "Light Theme"}
-            </span>
+          <button
+            className="menu-item"
+            onClick={() => {
+              setShowShare(true);
+              setOpen(false);
+            }}
+          >
+            <span className="material-symbols-outlined">public</span>
+            <span className="menu-item-label">Share Session</span>
+          </button>
+
+          {/* Matches the portal: leading icon + label are STATIC; only the
+              toggle_on/toggle_off switch icon reflects the current theme. */}
+          <button className="menu-item" onClick={toggle}>
+            <span className="material-symbols-outlined">dark_mode</span>
+            <span className="menu-item-label">Dark Theme</span>
             <span className="material-symbols-outlined theme-switch">
-              {theme === "dark" ? "toggle_on" : "toggle_off"}
+              {isDark ? "toggle_on" : "toggle_off"}
             </span>
           </button>
 
@@ -123,6 +121,9 @@ export function UserMenu() {
 
       {showApiKey && (
         <CreateApiKeyDialog onClose={() => setShowApiKey(false)} />
+      )}
+      {showShare && (
+        <CreateSharedSessionDialog onClose={() => setShowShare(false)} />
       )}
     </div>
   );

--- a/package/zerobias/example-nextjs-v2/src/lib/errors.test.ts
+++ b/package/zerobias/example-nextjs-v2/src/lib/errors.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { toUserMessage } from "./errors";
+
+describe("toUserMessage", () => {
+  it("maps 401 to a permission/session message", () => {
+    expect(toUserMessage({ response: { status: 401 } })).toMatch(
+      /permission|sign in|session/i,
+    );
+  });
+
+  it("maps 403 to a permission/session message", () => {
+    expect(toUserMessage({ response: { status: 403 } })).toMatch(
+      /permission|sign in|session/i,
+    );
+  });
+
+  it("maps 404 to a not-found message", () => {
+    expect(toUserMessage({ response: { status: 404 } })).toMatch(
+      /couldn.?t find|not found/i,
+    );
+  });
+
+  it("maps 429 to a rate-limit message", () => {
+    expect(toUserMessage({ response: { status: 429 } })).toMatch(
+      /too many|wait a moment/i,
+    );
+  });
+
+  it("maps 5xx to a server-problem message", () => {
+    expect(toUserMessage({ response: { status: 503 } })).toMatch(
+      /server|try again/i,
+    );
+  });
+
+  it("reads a status from `status` directly (not just `response.status`)", () => {
+    expect(toUserMessage({ status: 401 })).toMatch(/permission|sign in|session/i);
+  });
+
+  it("treats a response-less request error as a network problem", () => {
+    expect(toUserMessage({ code: "ERR_NETWORK" })).toMatch(
+      /reach the server|connection/i,
+    );
+  });
+
+  it("falls back to a generic message for an unknown error", () => {
+    expect(toUserMessage(new Error("boom"))).toMatch(/something went wrong/i);
+    expect(toUserMessage("weird")).toMatch(/something went wrong/i);
+    expect(toUserMessage(undefined)).toMatch(/something went wrong/i);
+  });
+
+  it("NEVER leaks the raw error text to the returned message", () => {
+    const secret = "SELECT * FROM users; connection refused at 10.0.0.5:5432";
+    const err = Object.assign(new Error(secret), { response: { status: 500 } });
+    const msg = toUserMessage(err);
+    expect(msg).not.toContain(secret);
+    expect(msg).not.toMatch(/SELECT|10\.0\.0\.5|refused/);
+  });
+});

--- a/package/zerobias/example-nextjs-v2/src/lib/errors.ts
+++ b/package/zerobias/example-nextjs-v2/src/lib/errors.ts
@@ -1,0 +1,49 @@
+/**
+ * Turns any thrown value into a safe, user-facing message.
+ *
+ * Feature code should show `toUserMessage(err)` in the UI and log the raw `err`
+ * to the console for developers — never surface the raw error text, which can
+ * leak backend details (SQL, hostnames, stack traces).
+ */
+
+/** Best-effort extraction of an HTTP status from common client/axios error shapes. */
+function httpStatusOf(err: unknown): number | undefined {
+  if (typeof err !== "object" || err === null) return undefined;
+  const e = err as {
+    status?: unknown;
+    response?: { status?: unknown };
+  };
+  const candidate = e.response?.status ?? e.status;
+  return typeof candidate === "number" ? candidate : undefined;
+}
+
+/** A request that never got a response (network down, CORS, DNS, timeout). */
+function isNetworkError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { code?: unknown; response?: unknown; request?: unknown };
+  if (e.code === "ERR_NETWORK" || e.code === "ECONNABORTED") return true;
+  // axios sets `request` but not `response` when the request was sent but
+  // nothing came back.
+  return e.request != null && e.response == null;
+}
+
+export function toUserMessage(err: unknown): string {
+  const status = httpStatusOf(err);
+
+  if (status === 401 || status === 403) {
+    return "You don't have permission to do that, or your session may have expired. Try signing in again.";
+  }
+  if (status === 404) {
+    return "We couldn't find what you were looking for.";
+  }
+  if (status === 429) {
+    return "Too many requests right now — please wait a moment and try again.";
+  }
+  if (status !== undefined && status >= 500) {
+    return "The server ran into a problem. Please try again in a moment.";
+  }
+  if (isNetworkError(err)) {
+    return "Couldn't reach the server. Check your connection and try again.";
+  }
+  return "Something went wrong. Please try again.";
+}

--- a/package/zerobias/example-nextjs-v2/src/lib/listbox-nav.test.ts
+++ b/package/zerobias/example-nextjs-v2/src/lib/listbox-nav.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { listboxKeyAction } from "./listbox-nav";
+
+describe("listboxKeyAction", () => {
+  it("ArrowDown with nothing active enters at the first row", () => {
+    expect(listboxKeyAction("ArrowDown", -1, 3)).toEqual({ type: "move", index: 0 });
+  });
+
+  it("ArrowDown advances and clamps at the last row (no wrap)", () => {
+    expect(listboxKeyAction("ArrowDown", 0, 3)).toEqual({ type: "move", index: 1 });
+    expect(listboxKeyAction("ArrowDown", 2, 3)).toEqual({ type: "move", index: 2 });
+  });
+
+  it("ArrowUp with nothing active enters at the last row", () => {
+    expect(listboxKeyAction("ArrowUp", -1, 3)).toEqual({ type: "move", index: 2 });
+  });
+
+  it("ArrowUp retreats and clamps at the first row (no wrap)", () => {
+    expect(listboxKeyAction("ArrowUp", 2, 3)).toEqual({ type: "move", index: 1 });
+    expect(listboxKeyAction("ArrowUp", 0, 3)).toEqual({ type: "move", index: 0 });
+  });
+
+  it("Home/End jump to the first/last row", () => {
+    expect(listboxKeyAction("Home", 2, 3)).toEqual({ type: "move", index: 0 });
+    expect(listboxKeyAction("End", 0, 3)).toEqual({ type: "move", index: 2 });
+  });
+
+  it("Enter/Space select the active row", () => {
+    expect(listboxKeyAction("Enter", 1, 3)).toEqual({ type: "select" });
+    expect(listboxKeyAction(" ", 1, 3)).toEqual({ type: "select" });
+  });
+
+  it("Enter/Space with no active row is a no-op", () => {
+    expect(listboxKeyAction("Enter", -1, 3)).toEqual({ type: "none" });
+  });
+
+  it("Escape and Tab close the list", () => {
+    expect(listboxKeyAction("Escape", 1, 3)).toEqual({ type: "close" });
+    expect(listboxKeyAction("Tab", 1, 3)).toEqual({ type: "close" });
+  });
+
+  it("empty list: Escape/Tab close, everything else is a no-op", () => {
+    expect(listboxKeyAction("Escape", -1, 0)).toEqual({ type: "close" });
+    expect(listboxKeyAction("Tab", -1, 0)).toEqual({ type: "close" });
+    expect(listboxKeyAction("ArrowDown", -1, 0)).toEqual({ type: "none" });
+  });
+
+  it("unhandled keys are no-ops", () => {
+    expect(listboxKeyAction("a", 1, 3)).toEqual({ type: "none" });
+  });
+});

--- a/package/zerobias/example-nextjs-v2/src/lib/listbox-nav.ts
+++ b/package/zerobias/example-nextjs-v2/src/lib/listbox-nav.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure keyboard-navigation math for a single-select listbox (WAI-ARIA pattern).
+ *
+ * The component owns focus, `aria-activedescendant`, and selection; this helper
+ * only answers "given a keypress and the current active row, what should happen?"
+ * Keeping it pure makes it unit-testable with no DOM. See `OrgSwitcher`.
+ */
+export type ListboxKeyAction =
+  | { type: "move"; index: number }
+  | { type: "select" }
+  | { type: "close" }
+  | { type: "none" };
+
+/**
+ * @param key         the `KeyboardEvent.key` value
+ * @param activeIndex currently highlighted row, or -1 when none is
+ * @param count       number of rows in the list
+ */
+export function listboxKeyAction(
+  key: string,
+  activeIndex: number,
+  count: number,
+): ListboxKeyAction {
+  if (count === 0) {
+    return key === "Escape" || key === "Tab" ? { type: "close" } : { type: "none" };
+  }
+
+  const clamp = (i: number) => Math.max(0, Math.min(count - 1, i));
+  const hasActive = activeIndex >= 0 && activeIndex < count;
+
+  switch (key) {
+    case "ArrowDown":
+      // From "nothing active", ArrowDown enters at the top.
+      return { type: "move", index: hasActive ? clamp(activeIndex + 1) : 0 };
+    case "ArrowUp":
+      // From "nothing active", ArrowUp enters at the bottom.
+      return { type: "move", index: hasActive ? clamp(activeIndex - 1) : count - 1 };
+    case "Home":
+      return { type: "move", index: 0 };
+    case "End":
+      return { type: "move", index: count - 1 };
+    case "Enter":
+    case " ":
+      return hasActive ? { type: "select" } : { type: "none" };
+    case "Escape":
+    case "Tab":
+      return { type: "close" };
+    default:
+      return { type: "none" };
+  }
+}

--- a/package/zerobias/example-nextjs-v2/src/lib/status-tone.test.ts
+++ b/package/zerobias/example-nextjs-v2/src/lib/status-tone.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { statusTone } from "./status-tone";
+
+describe("statusTone", () => {
+  it("maps healthy terminal statuses to a solid green dot", () => {
+    expect(statusTone("up")).toEqual({ tone: "up", outlined: false, label: "UP" });
+    expect(statusTone("ok").tone).toBe("up");
+    expect(statusTone("active").outlined).toBe(false);
+  });
+
+  it("maps transitional statuses to an outlined (hollow) green dot", () => {
+    expect(statusTone("standby")).toEqual({
+      tone: "up",
+      outlined: true,
+      label: "STANDBY",
+    });
+    expect(statusTone("running").outlined).toBe(true);
+  });
+
+  it("maps failure statuses to red", () => {
+    expect(statusTone("down").tone).toBe("down");
+    expect(statusTone("error").tone).toBe("down");
+    expect(statusTone("failed").outlined).toBe(false);
+  });
+
+  it("maps degraded/waiting to amber and provisioning/review to blue", () => {
+    expect(statusTone("pending").tone).toBe("warn");
+    expect(statusTone("draft").tone).toBe("info");
+    expect(statusTone("in_progress")).toEqual({
+      tone: "info",
+      outlined: true,
+      label: "IN PROGRESS",
+    });
+  });
+
+  it("is case-insensitive on the tone lookup", () => {
+    expect(statusTone("UP").tone).toBe("up");
+    expect(statusTone("StandBy").outlined).toBe(true);
+  });
+
+  it("falls back to neutral for unknown statuses but still formats the label", () => {
+    expect(statusTone("banana").tone).toBe("neutral");
+    expect(statusTone("needs_data")).toEqual({
+      tone: "neutral",
+      outlined: false,
+      label: "NEEDS DATA",
+    });
+  });
+
+  it("handles a missing status", () => {
+    expect(statusTone(undefined)).toEqual({
+      tone: "neutral",
+      outlined: false,
+      label: "UNKNOWN",
+    });
+  });
+});

--- a/package/zerobias/example-nextjs-v2/src/lib/status-tone.ts
+++ b/package/zerobias/example-nextjs-v2/src/lib/status-tone.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure mapping from a resource's operational status to how its `StatusDot`
+ * should render: a color `tone`, whether it's `outlined` (a transitional state),
+ * and the display `label`. Grouped after ngx-library's `zb-resource-status`
+ * buckets. Kept pure + separate from the component so it's unit-testable with no
+ * DOM (see `status-tone.test.ts`), mirroring `listbox-nav`.
+ */
+
+export type StatusTone = "up" | "down" | "warn" | "info" | "neutral";
+
+// Operational status -> color tone. Unmapped statuses fall through to `neutral`.
+const TONE: Record<string, StatusTone> = {
+  // green — healthy / usable
+  up: "up",
+  ok: "up",
+  on: "up",
+  ready: "up",
+  active: "up",
+  done: "up",
+  success: "up",
+  complete: "up",
+  completed: "up",
+  standby: "up",
+  starting: "up",
+  running: "up",
+  processing: "up",
+  connected: "up",
+  configuring: "up",
+  installing: "up",
+  downloading: "up",
+  verifying: "up",
+  verified: "up",
+  // red — down / failed
+  down: "down",
+  error: "down",
+  failed: "down",
+  failure: "down",
+  invalid: "down",
+  stopping: "down",
+  deleting: "down",
+  deleted: "down",
+  rejected: "down",
+  // amber — degraded / waiting
+  degraded: "warn",
+  warning: "warn",
+  pending: "warn",
+  suspended: "warn",
+  on_hold: "warn",
+  not_ready: "warn",
+  // blue — provisioning / review
+  created: "info",
+  enabled: "info",
+  draft: "info",
+  in_progress: "info",
+  under_review: "info",
+  awaiting_review: "info",
+};
+
+// Transitional statuses render as an OUTLINED (hollow) dot — same color as their
+// solid counterpart, ring only. Mirrors ngx-library's `background:transparent`
+// dot for standby/starting/running/etc (vs the solid dot for terminal states).
+const OUTLINED = new Set([
+  "standby",
+  "starting",
+  "running",
+  "processing",
+  "connected",
+  "configuring",
+  "installing",
+  "downloading",
+  "verifying",
+  "in_progress",
+  "under_review",
+  "suspended",
+]);
+
+export function statusTone(status?: string): {
+  tone: StatusTone;
+  outlined: boolean;
+  label: string;
+} {
+  const raw = (status ?? "unknown").toString();
+  const key = raw.toLowerCase();
+  return {
+    tone: TONE[key] ?? "neutral",
+    outlined: OUTLINED.has(key),
+    label: raw.replace(/_/g, " ").toUpperCase(),
+  };
+}

--- a/package/zerobias/example-nextjs-v2/src/lib/theme.ts
+++ b/package/zerobias/example-nextjs-v2/src/lib/theme.ts
@@ -1,0 +1,151 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Theme controller — a faithful port of the portal's `ZbThemeService`
+ * (`@zerobias-org/ngx-library`) so this app themes **identically to the portal**,
+ * including when it runs embedded in the portal's iframe.
+ *
+ * The model (must match the portal exactly):
+ *  - Preference is stored in `localStorage` under `zb-theme-preference` as
+ *    `"light" | "dark" | "system"`, defaulting to `"system"`.
+ *  - Dark mode applies the **`dark-theme` class to `<body>`** (and to `<html>`
+ *    via the FOWT-prevention script in `layout.tsx`) and sets
+ *    `document.documentElement.style.colorScheme` — so light is the default and
+ *    `.dark-theme` is the override (see `_tokens.scss`).
+ *  - **Standalone** (top-level window): resolves its own preference and, while
+ *    the preference is `"system"`, follows the OS `prefers-color-scheme` setting.
+ *  - **Embedded in the portal iframe**: does NOT self-apply on load; it listens
+ *    for the portal's `theme_change` `postMessage` and follows the portal's theme.
+ *
+ * Matching this model is what lets the app's theme stay in lockstep with the
+ * portal when embedded — a bespoke toggle would drift.
+ */
+export type ThemePreference = "light" | "dark" | "system";
+
+const STORAGE_KEY = "zb-theme-preference";
+const DARK_THEME_CLASS = "dark-theme";
+const THEME_CHANGE_MESSAGE_TYPE = "theme_change";
+
+function systemPrefersDark(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    (window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false)
+  );
+}
+
+function loadPreference(): ThemePreference {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      return stored;
+    }
+  } catch {
+    // localStorage unavailable (SSR/prerender, private browsing) — use the default.
+  }
+  return "system";
+}
+
+function applyDarkClass(isDark: boolean): void {
+  // Apply to BOTH <html> and <body>. <html> is required: the derived menu tokens
+  // (`--zb-menu-bg: var(--zb-background-card)`) are declared on `:root`, so their
+  // `var()` resolves against `--zb-background-card` *on html* — putting the dark
+  // override only on <body> would leave those frozen at their light values.
+  // <body> matches the portal's ZbThemeService + its postMessage handler.
+  document.documentElement.classList.toggle(DARK_THEME_CLASS, isDark);
+  document.body.classList.toggle(DARK_THEME_CLASS, isDark);
+  // Drives native UI (scrollbars, form controls) — the portal does this too.
+  document.documentElement.style.colorScheme = isDark ? "dark" : "light";
+}
+
+class ThemeController {
+  private preference: ThemePreference = loadPreference();
+  private readonly listeners = new Set<() => void>();
+  private readonly embedded =
+    typeof window !== "undefined" && window.self !== window.top;
+
+  constructor() {
+    if (typeof window === "undefined") return;
+    // A child app in the portal iframe follows the portal's theme messages.
+    window.addEventListener("message", this.onMessage);
+    if (!this.embedded) {
+      this.apply();
+      window
+        .matchMedia?.("(prefers-color-scheme: dark)")
+        .addEventListener?.("change", () => {
+          if (this.preference === "system") this.apply();
+        });
+    }
+  }
+
+  isDarkMode(): boolean {
+    if (this.preference === "system") return systemPrefersDark();
+    return this.preference === "dark";
+  }
+
+  getPreference(): ThemePreference {
+    return this.preference;
+  }
+
+  setPreference(preference: ThemePreference): void {
+    this.preference = preference;
+    try {
+      localStorage.setItem(STORAGE_KEY, preference);
+    } catch {
+      // localStorage unavailable — apply for this session anyway.
+    }
+    this.apply();
+  }
+
+  /** Two-state flip, matching the portal's user-menu toggle (never sets "system"). */
+  toggle(): void {
+    this.setPreference(this.isDarkMode() ? "light" : "dark");
+  }
+
+  /** Three-state cycle: system -> light -> dark -> system. */
+  cycle(): void {
+    const next: ThemePreference =
+      this.preference === "system"
+        ? "light"
+        : this.preference === "light"
+          ? "dark"
+          : "system";
+    this.setPreference(next);
+  }
+
+  subscribe = (fn: () => void): (() => void) => {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  };
+
+  private apply(): void {
+    applyDarkClass(this.isDarkMode());
+    this.listeners.forEach((fn) => fn());
+  }
+
+  private onMessage = (event: MessageEvent) => {
+    if (event.data?.type === THEME_CHANGE_MESSAGE_TYPE) {
+      applyDarkClass(Boolean(event.data.isDark));
+      this.listeners.forEach((fn) => fn());
+    }
+  };
+}
+
+let controller: ThemeController | null = null;
+function getController(): ThemeController {
+  if (!controller) controller = new ThemeController();
+  return controller;
+}
+
+/**
+ * React binding for the theme controller. Returns the current dark state and a
+ * two-state `toggle` (matching the portal user menu). Re-renders on any theme
+ * change — including portal-driven changes when embedded.
+ */
+export function useTheme(): { isDark: boolean; toggle: () => void } {
+  const isDark = useSyncExternalStore(
+    (cb) => getController().subscribe(cb),
+    () => getController().isDarkMode(),
+    () => false, // server/prerender snapshot: light (matches the FOWT default)
+  );
+  return { isDark, toggle: () => getController().toggle() };
+}

--- a/package/zerobias/example-nextjs-v2/src/styles/_components.scss
+++ b/package/zerobias/example-nextjs-v2/src/styles/_components.scss
@@ -128,6 +128,184 @@
   color: #fff;
 }
 
+// ---------- Resource status dots (modeled on ngx-library zb-resource-status showDot) ----------
+// A small colored circle: SOLID fill = terminal state, OUTLINED (transparent
+// fill + colored ring) = transitional state such as `standby` — the same
+// solid-vs-outlined distinction ngx-library's dot makes, so `up` and `standby`
+// (both green) stay distinguishable. Colors are ngx-library's `--zb-color-*`
+// tokens (mirrored in _tokens.scss), theme-invariant like the portal.
+.status-dot {
+  display: inline-block;
+  flex: none;
+  // content-box + 14px + 3px border = ngx-library's size-default circle exactly
+  // (14px hole, 3px ring, 20px total). border-box would shrink the hole and make
+  // the outlined ring read ~2x too thick.
+  box-sizing: content-box;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 3px solid var(--zb-color-gray); // neutral / unknown
+  background: var(--zb-color-gray);
+}
+.status-dot.up {
+  background: var(--zb-color-success);
+  border-color: var(--zb-color-success);
+}
+.status-dot.down {
+  background: var(--zb-color-error);
+  border-color: var(--zb-color-error);
+}
+.status-dot.warn {
+  background: var(--zb-color-warning);
+  border-color: var(--zb-color-warning);
+}
+.status-dot.info {
+  background: var(--zb-color-info);
+  border-color: var(--zb-color-info);
+}
+.status-dot.neutral {
+  background: var(--zb-color-gray);
+  border-color: var(--zb-color-gray);
+}
+// Transitional (e.g. standby) — colored ring, hollow centre.
+.status-dot.outlined {
+  background: transparent;
+}
+
+// ---------- In-place loading: spinner (mat-spinner equivalent) + skeletons ----------
+// The <Spinner> SVG; the arc is currentColor, so it recolors with the text color
+// (default cyan). Rotation reuses the shared `zb-spin` keyframes (_layout.scss).
+.spinner-svg {
+  display: inline-block;
+  vertical-align: middle;
+  color: var(--zb-primary);
+  animation: zb-spin 0.9s linear infinite;
+}
+// Inside a button (ButtonLabel), the spinner inherits the button's text color so
+// it reads correctly on the fill — white on a primary `.btn`, cyan on `.btn-ghost`
+// — instead of the standalone cyan default (which would vanish on the cyan fill).
+.btn .spinner-svg,
+.btn-ghost .spinner-svg {
+  color: inherit;
+}
+// Spinner + label on one line (e.g. "⟳ Loading products…").
+.loading-line {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--zb-space-sm);
+}
+// Skeleton placeholders — a token-colored block that pulses while data loads.
+.skeleton {
+  display: inline-block;
+  background: var(--zb-divider);
+  border-radius: var(--zb-radius-sm);
+  animation: zb-pulse 1.4s ease-in-out infinite;
+}
+.skeleton-bar {
+  width: 80%;
+  height: 12px;
+}
+.skeleton-circle {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+}
+@keyframes zb-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+// ---------- Connection picker (accessible listbox with status chips) ----------
+// A WAI-ARIA listbox that replaces a native <select> so each row can carry a
+// StatusDot. Mirrors the OrgSwitcher dropdown tokens so it flips with the theme.
+.conn-picker {
+  position: relative;
+}
+.conn-picker-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--zb-space-sm);
+  width: 100%;
+  background: var(--zb-background-input);
+  color: var(--zb-text);
+  border: 1px solid var(--zb-divider);
+  border-radius: var(--zb-radius-sm);
+  padding: 8px 10px;
+  font: inherit;
+  font-family: var(--zb-font-body);
+  text-align: left;
+  cursor: pointer;
+}
+.conn-picker-trigger:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.conn-picker-trigger:focus-visible {
+  outline: none;
+  border-color: var(--zb-primary);
+  box-shadow: 0 0 0 3px var(--zb-focus-ring);
+}
+.conn-picker-trigger .material-symbols-outlined {
+  font-size: 20px;
+  color: var(--zb-secondary-text);
+}
+.conn-picker-value {
+  display: flex;
+  align-items: center;
+  gap: var(--zb-space-sm);
+  min-width: 0;
+}
+.conn-picker-placeholder {
+  color: var(--zb-secondary-text);
+}
+.conn-picker-list {
+  position: absolute;
+  top: calc(100% + var(--zb-space-xs));
+  left: 0;
+  right: 0;
+  z-index: 10;
+  list-style: none;
+  margin: 0;
+  padding: var(--zb-space-xs) 0;
+  max-height: 280px;
+  overflow-y: auto;
+  background: var(--zb-background-card);
+  border: 1px solid var(--zb-divider);
+  border-radius: var(--zb-radius-sm);
+  box-shadow: 1px 1px 8px 2px rgba(0, 0, 0, 0.4);
+}
+.conn-picker-list:focus {
+  outline: none;
+}
+.conn-picker-item {
+  display: flex;
+  align-items: center;
+  gap: var(--zb-space-sm);
+  padding: 8px 10px;
+  cursor: pointer;
+  color: var(--zb-text);
+}
+.conn-picker-item:hover,
+.conn-picker-item.active {
+  background: var(--zb-menu-hover);
+}
+.conn-picker-item.selected {
+  font-weight: 600;
+}
+.conn-picker-item.disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+.conn-picker-item.disabled:hover {
+  background: transparent;
+}
+
 // ---------- Buttons ----------
 .btn,
 .btn-ghost {

--- a/package/zerobias/example-nextjs-v2/src/styles/_layout.scss
+++ b/package/zerobias/example-nextjs-v2/src/styles/_layout.scss
@@ -20,19 +20,100 @@
   max-width: 420px;
   font-size: var(--zb-font-size-sm);
 }
-.spinner {
-  width: 34px;
-  height: 34px;
-  margin: 0 auto var(--zb-space-md);
-  border: 3px solid var(--zb-divider);
-  border-top-color: var(--zb-primary);
-  border-radius: 50%;
-  animation: zb-spin 0.9s linear infinite;
-}
 @keyframes zb-spin {
   to {
     transform: rotate(360deg);
   }
+}
+
+// ---------- "0" page preloader (port of the portal's .app-loading) ----------
+// The ZeroBias brand mark: a slashed "0" (Mitr font) with a cyan bar sweeping
+// across it (`zerobiasSlide`). Faithfully ported from zb-ui-lib components.scss;
+// the two sweep colors are the portal's `--zb-primary` / `--zb-primary-100`.
+.page-loader {
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--zb-space-md);
+  padding: var(--zb-space-lg);
+  text-align: center;
+  color: var(--zb-secondary-text);
+}
+.page-loader-label {
+  color: var(--zb-secondary-text);
+}
+.app-loading {
+  position: relative;
+  display: inline-block;
+  width: 34px;
+  text-align: center;
+  font-family: var(--font-mitr), Mitr, sans-serif;
+  font-size: 50px;
+  line-height: 32px;
+  color: var(--zb-text);
+
+  &::before {
+    content: " ";
+    position: absolute;
+    top: -14px;
+    left: 0;
+    right: -2px;
+    margin: auto;
+    height: 8px;
+    width: 34px;
+    background: linear-gradient(
+      90deg,
+      var(--zb-primary) 0%,
+      var(--zb-primary-100) 0%
+    );
+    animation: zerobiasSlide 0.5s ease-out infinite alternate;
+  }
+}
+// The bar sweeps: a solid segment grows left->right (0-50%), then its trailing
+// edge catches up (50-100%), reversed each cycle by `alternate`.
+@keyframes zerobiasSlide {
+  0% {
+    background: linear-gradient(90deg, var(--zb-primary-100) 0%, var(--zb-primary) 0%, var(--zb-primary) 0%, var(--zb-primary-100) 0%);
+  }
+  12.5% {
+    background: linear-gradient(90deg, var(--zb-primary-100) 0%, var(--zb-primary) 0%, var(--zb-primary) 25%, var(--zb-primary-100) 25%);
+  }
+  25% {
+    background: linear-gradient(90deg, var(--zb-primary-100) 0%, var(--zb-primary) 0%, var(--zb-primary) 50%, var(--zb-primary-100) 50%);
+  }
+  37.5% {
+    background: linear-gradient(90deg, var(--zb-primary-100) 0%, var(--zb-primary) 0%, var(--zb-primary) 75%, var(--zb-primary-100) 75%);
+  }
+  50% {
+    background: linear-gradient(90deg, var(--zb-primary-100) 0%, var(--zb-primary) 0%, var(--zb-primary) 100%, var(--zb-primary-100) 100%);
+  }
+  62.5% {
+    background: linear-gradient(90deg, var(--zb-primary-100) 25%, var(--zb-primary) 25%, var(--zb-primary) 100%, var(--zb-primary-100) 100%);
+  }
+  75% {
+    background: linear-gradient(90deg, var(--zb-primary-100) 50%, var(--zb-primary) 50%, var(--zb-primary) 100%, var(--zb-primary-100) 100%);
+  }
+  87.5% {
+    background: linear-gradient(90deg, var(--zb-primary-100) 75%, var(--zb-primary) 75%, var(--zb-primary) 100%, var(--zb-primary-100) 100%);
+  }
+  100% {
+    background: linear-gradient(90deg, var(--zb-primary-100) 100%, var(--zb-primary) 100%, var(--zb-primary) 100%, var(--zb-primary-100) 100%);
+  }
+}
+
+// Visually-hidden text for screen readers (loading status labels, etc.).
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .state {

--- a/package/zerobias/example-nextjs-v2/src/styles/_tokens.scss
+++ b/package/zerobias/example-nextjs-v2/src/styles/_tokens.scss
@@ -1,42 +1,46 @@
-// Design tokens — mirrors the ZeroBias portal's `--zb-*` variable system so a
-// Phase 2 light/dark switch is a values-only swap (no markup/selector changes).
+// Design tokens — mirrors the ZeroBias portal's `--zb-*` variable system so the
+// light/dark switch is a values-only swap (no markup/selector changes).
 //
-// Phase 1 ships DARK values only, matching the live portal (ci.zerobias.com).
-// Phase 2: add a `:root[data-theme="light"]` block overriding these same names.
+// Theme model matches the portal's `ZbThemeService` (@zerobias-org/ngx-library)
+// exactly: LIGHT is the default (bare `:root`); DARK is applied by adding the
+// `dark-theme` class to `<html>`/`<body>` (see src/lib/theme.ts). The toolbar
+// stays black in both themes, like the portal.
 
 :root {
-  // Brand
+  // Brand (theme-invariant)
   --zb-primary: #03aff0;
   --zb-primary-300: #20b7f8;
   --zb-primary-100: #c6e7ff;
   --zb-primary-contrast: #ffffff;
   --zb-primary-rgb: 3, 175, 240;
 
-  // Surfaces (dark) — portal: body #303030, cards/surfaces LIGHTER (#424242)
+  // Toolbar stays black in both themes (portal `portal-toolbar`)
   --zb-toolbar-bg: #000000;
-  --zb-background: #303030;         // app body — portal shell body is rgb(48,48,48)
-  --zb-background-card: #424242;    // panels/cards/menus — portal dark surface
-  --zb-background-elevated: #4a4a4a;
-  --zb-background-input: #2b2b2b;   // inputs slightly darker than card
 
-  // Text
-  --zb-text: #ffffff;
-  --zb-secondary-text: #9aa0a6;
-  --zb-text-on-primary: #ffffff;
+  // Surfaces (LIGHT default — portal --mat-sys light tokens)
+  --zb-background: #fafafa;         // app body
+  --zb-background-card: #ffffff;    // panels/cards/menus
+  --zb-background-elevated: #ffffff;
+  --zb-background-input: #ffffff;
 
-  // Lines / states
-  --zb-divider: rgba(255, 255, 255, 0.12);
-  --zb-hover-overlay: rgba(255, 255, 255, 0.06);
-  --zb-table-row-hover: rgba(3, 175, 240, 0.08);
-  --zb-focus-ring: rgba(3, 175, 240, 0.5);
+  // Text (LIGHT default)
+  --zb-text: #111111;
+  --zb-secondary-text: #757575;
+  --zb-text-on-primary: #ffffff;    // white on primary cyan (invariant)
 
-  // Menu / dropdown — portal popover uses the card surface (#424242 in dark)
+  // Lines / states (LIGHT default)
+  --zb-divider: #e3e3e3;
+  --zb-hover-overlay: rgba(0, 0, 0, 0.04);
+  --zb-table-row-hover: rgb(237, 248, 254);
+  --zb-focus-ring: rgba(3, 175, 240, 0.5); // cyan (invariant)
+
+  // Menu / dropdown — derived from the surfaces above, so they flip for free.
   --zb-menu-bg: var(--zb-background-card);
   --zb-menu-divider: var(--zb-divider);
   --zb-menu-hover: var(--zb-hover-overlay);
   --zb-menu-input-bg: var(--zb-background-input);
 
-  // Status (from portal --zb-task-status-* / severity)
+  // Status (theme-invariant — from portal --zb-task-status-* / severity)
   --zb-status-success: #1f9e6a;    // done / published
   --zb-status-info: #2a6fd6;       // in-progress / draft
   --zb-status-neutral: #6b778c;    // backlog
@@ -45,6 +49,24 @@
   --zb-status-purple: #6554c0;     // "Project" parent chip
   --zb-status-blue: #2a6fd6;       // "Boundary" parent chip
   --zb-status-orange: #d98a00;     // "Organization" parent chip
+
+  // Resource/chip color tokens — mirrored verbatim from ngx-library's
+  // `_theme-variables.scss` (@zerobias-org/ngx-library), theme-invariant there.
+  // The StatusDot references these so its palette IS the library's, not a copy.
+  // `*-on-light-bg` = text for a light fill; `*-on-dark-bg` = text for a saturated fill.
+  --zb-color-success: #5ad403;
+  --zb-color-error: #cc0000;
+  --zb-color-warning: #ffb300;
+  --zb-color-pending: #fbc712;
+  --zb-color-info: #2b9cf1;
+  --zb-color-gray: #cdcdcd;
+  --zb-color-white: #ffffff;
+  --zb-text-on-light-bg: rgba(0, 0, 0, 0.87);
+  --zb-text-on-dark-bg: #ffffff;
+
+  // Elevation (LIGHT default)
+  --zb-card-shadow: 8px 8px 16px -6px rgba(0, 0, 0, 0.1);
+  --zb-card-shadow-hover: 8px 8px 16px -4px rgba(0, 0, 0, 0.3);
 
   // Typography — the portal is all Roboto; weight carries the hierarchy.
   --zb-font-body: var(--font-roboto), Roboto, system-ui, sans-serif;
@@ -66,26 +88,24 @@
   --zb-radius-md: 5px;
   --zb-radius-pill: 50px;
 
-  // Elevation
-  --zb-card-shadow: 8px 8px 16px -6px rgba(0, 0, 0, 0.35);
-  --zb-card-shadow-hover: 8px 8px 16px -4px rgba(0, 0, 0, 0.55);
-
-  color-scheme: dark;
+  color-scheme: light;
 }
 
-// First-cut LIGHT theme (values from the portal's --mat-sys light tokens).
-// The toolbar stays black in both, like the portal. Toggled from the user menu.
-:root[data-theme="light"] {
-  --zb-background: #fafafa;
-  --zb-background-card: #ffffff;
-  --zb-background-elevated: #ffffff;
-  --zb-background-input: #ffffff;
-  --zb-text: #111111;
-  --zb-secondary-text: #757575;
-  --zb-divider: #e3e3e3;
-  --zb-hover-overlay: rgba(0, 0, 0, 0.04);
-  --zb-table-row-hover: rgb(237, 248, 254);
-  --zb-card-shadow: 8px 8px 16px -6px rgba(0, 0, 0, 0.1);
-  --zb-card-shadow-hover: 8px 8px 16px -4px rgba(0, 0, 0, 0.3);
-  color-scheme: light;
+// DARK override — the portal applies the `dark-theme` class to <html> (FOWT
+// script) and <body> (ZbThemeService); either matches. Values match the live
+// portal (ci.zerobias.com): body #303030, surfaces #424242.
+html.dark-theme,
+body.dark-theme {
+  --zb-background: #303030;
+  --zb-background-card: #424242;
+  --zb-background-elevated: #4a4a4a;
+  --zb-background-input: #2b2b2b;
+  --zb-text: #ffffff;
+  --zb-secondary-text: #9aa0a6;
+  --zb-divider: rgba(255, 255, 255, 0.12);
+  --zb-hover-overlay: rgba(255, 255, 255, 0.06);
+  --zb-table-row-hover: rgba(3, 175, 240, 0.08);
+  --zb-card-shadow: 8px 8px 16px -6px rgba(0, 0, 0, 0.35);
+  --zb-card-shadow-hover: 8px 8px 16px -4px rgba(0, 0, 0, 0.55);
+  color-scheme: dark;
 }

--- a/package/zerobias/example-nextjs-v2/src/styles/_user-menu.scss
+++ b/package/zerobias/example-nextjs-v2/src/styles/_user-menu.scss
@@ -151,12 +151,27 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.org-switch-item:hover {
+.org-switch-item:hover,
+.org-switch-item.active {
   background: var(--zb-menu-hover);
 }
 .org-switch-item.selected {
   color: var(--zb-primary);
   font-weight: 600;
+}
+// Focus moves into the list programmatically on open; the visible cue is the
+// highlighted row (`aria-activedescendant` -> `.active`), so hide the outline.
+.org-switch-list:focus {
+  outline: none;
+}
+// Loading row shown while the org list is still resolving.
+.org-switch-loading {
+  display: flex;
+  align-items: center;
+  gap: var(--zb-space-sm);
+  padding: 8px 10px;
+  font-size: var(--zb-font-size-sm);
+  color: var(--zb-secondary-text);
 }
 .ellipsis {
   overflow: hidden;

--- a/package/zerobias/example-nextjs-v2/vitest.config.ts
+++ b/package/zerobias/example-nextjs-v2/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Unit tests run under Vitest. Pure logic (e.g. `src/lib/`) uses the default
+ * `node` environment; component/DOM tests can opt into `jsdom` per-file with a
+ * `// @vitest-environment jsdom` pragma.
+ */
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
Promote **example-nextjs-v2** to **phase 2 (v0.2.0)** to sync this env with uat.

- **App-only diff** — 40 files, all under `package/zerobias/example-nextjs-v2/`, promoted verbatim from `upstream/uat` (which is at 0.2.0). This env was at 0.1.0.
- Nothing outside the example app is touched (no sme-mart, no root/workflow drift).
- Same surgical promote pattern as #65 / #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)