### PR TITLE
fix(example-nextjs-v2): authenticate Hub SDK client with platform session (v0.2.1)

### DIFF
--- a/package/zerobias/example-nextjs-v2/CHANGELOG.md
+++ b/package/zerobias/example-nextjs-v2/CHANGELOG.md
@@ -14,6 +14,18 @@ the changes into their own app easier.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-10
+
+### Fixed
+- **Module chain — Hub connect 401 in the browser.** The GitHub Hub SDK client
+  (`GithubHubImpl`) is a separate HTTP client and does not inherit the platform
+  clients' auth interceptor, so its `connect()` call to
+  `/api/hub/targets/<id>/metadata` was sent with **no `Authorization` header** and
+  the dana proxy returned `401` on uat/prod (local dev was unaffected because it
+  authenticates with the API key). Fixed by passing the platform **session id**
+  (`api.getZerobiasSessionId()`) into `HubConnectionProfile`'s `session` arg, so
+  the SDK sends `Authorization: session <id>` like `danaClient` / `hubClient`.
+
 ## [0.2.0] - 2026-07-09
 
 Phase 2 — the GitHub **module chain** and **shared-session key**, plus

--- a/package/zerobias/example-nextjs-v2/package-lock.json
+++ b/package/zerobias/example-nextjs-v2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "example-nextjs-v2",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "example-nextjs-v2",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@auditlogic/hub-sdk-github-github": "^7.1.6",
         "@zerobias-com/dana-sdk": "^2.0.4",

--- a/package/zerobias/example-nextjs-v2/package.json
+++ b/package/zerobias/example-nextjs-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-nextjs-v2",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "ZeroBias v2 client + SDK example app (Next.js). Canonical patterns for building a custom app on the ZeroBias platform.",
   "scripts": {

--- a/package/zerobias/example-nextjs-v2/src/app/module/page.tsx
+++ b/package/zerobias/example-nextjs-v2/src/app/module/page.tsx
@@ -219,13 +219,19 @@ export default function ModulePage() {
     const cached = clientsRef.current.get(targetId);
     if (cached) return cached; // reuse — don't reconnect for every list call
     // The Hub routes to the target connection/scope; it injects the stored
-    // GitHub credentials server-side. In local dev we authenticate the Hub call
-    // with the app's API key; in the browser session the platform cookie is used.
+    // GitHub credentials server-side. But WE still have to authenticate the Hub
+    // call itself — the Hub SDK client is a separate HTTP client, so it doesn't
+    // inherit the platform clients' auth interceptor. Local dev authenticates
+    // with the app's API key; in the browser we pass the platform SESSION id
+    // (`api.getZerobiasSessionId()`), which the SDK sends as
+    // `Authorization: session <id>` — matching danaClient/hubClient. Without it
+    // the request has no Authorization header and the dana proxy returns 401.
+    const sessionId = api!.getZerobiasSessionId();
     const profile = new HubConnectionProfile(
       getZerobiasClientUrl("hub", true, env.isLocalDev),
       api!.toUUID(targetId),
       env.isLocalDev ? env.apiKey : undefined,
-      undefined,
+      env.isLocalDev || !sessionId ? undefined : api!.toUUID(sessionId),
       org ? api!.toUUID(org.id) : undefined,
     );
     const client = new GithubHubImpl();


### PR DESCRIPTION
## Bug
On uat/prod, the GitHub module demo's Hub connect failed with **401**. `GithubHubImpl.connect()` -> `GET /api/hub/targets/<id>/metadata` was sent with **no `Authorization` header**, so the dana proxy rejected it (`err.unable.to.authenticate`). Local dev was unaffected because it authenticates with the API key.

## Root cause
The Hub SDK client (`GithubHubImpl`) is a **separate HTTP client** and does not inherit the platform clients' auth interceptor. The connect code passed `undefined` for `HubConnectionProfile.session`, so in the browser (no apiKey, no session) it sent no credential.

Confirmed in DevTools on uat: working `hub/connectionSearch` sends `authorization: session <id>`; the failing `targets/<id>/metadata` sent none.

## Fix
Pass the platform session id (`api.getZerobiasSessionId()`) into `HubConnectionProfile.session`, so the SDK sends `Authorization: session <id>` — matching `danaClient`/`hubClient`. Local dev keeps using the API key. This is the designed integration point, and a good canonical example for the reference app.

- `src/app/module/page.tsx` — session wired into the profile
- Bump `0.2.0 -> 0.2.1`; CHANGELOG entry under Fixed

## Test plan
- [ ] Deploy to uat, open `/module`, pick a good connection -> confirm `metadata` call now carries `Authorization: session …` and returns 200, org + repos load.
- [ ] tsc: 0 errors, eslint clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)