### PR TITLE
feat(example-nextjs-v2): show app version in account menu (v0.2.2)

### DIFF
--- a/package/zerobias/example-nextjs-v2/CHANGELOG.md
+++ b/package/zerobias/example-nextjs-v2/CHANGELOG.md
@@ -14,6 +14,14 @@ the changes into their own app easier.
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-07-10
+
+### Added
+- **App version in the account menu.** The user dropdown shows the running app
+  version (e.g. `v0.2.2`) on the right of the Sign Out row. Sourced from
+  `package.json` at build via `NEXT_PUBLIC_APP_VERSION` (`next.config.ts`), so the
+  displayed version always matches the release — one source of truth.
+
 ## [0.2.1] - 2026-07-10
 
 ### Fixed

--- a/package/zerobias/example-nextjs-v2/next.config.ts
+++ b/package/zerobias/example-nextjs-v2/next.config.ts
@@ -1,4 +1,11 @@
 import type { NextConfig } from "next";
+import { createRequire } from "node:module";
+
+// App version, sourced from package.json at build so the UI (user menu footer)
+// shows the same version the release is tagged with — one source of truth.
+const { version } = createRequire(import.meta.url)("./package.json") as {
+  version: string;
+};
 
 /**
  * ONE config for every environment — no per-env file copying.
@@ -28,6 +35,8 @@ const base: NextConfig = {
   reactStrictMode: true,
   trailingSlash: true,
   skipTrailingSlashRedirect: true,
+  // Inlined into the client bundle so components can read the app version.
+  env: { NEXT_PUBLIC_APP_VERSION: version },
   // Static export cannot use the Next image optimizer.
   images: { unoptimized: true },
   // Pin the workspace root to this app so a stray parent lockfile doesn't

--- a/package/zerobias/example-nextjs-v2/package-lock.json
+++ b/package/zerobias/example-nextjs-v2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "example-nextjs-v2",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "example-nextjs-v2",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@auditlogic/hub-sdk-github-github": "^7.1.6",
         "@zerobias-com/dana-sdk": "^2.0.4",

--- a/package/zerobias/example-nextjs-v2/package.json
+++ b/package/zerobias/example-nextjs-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-nextjs-v2",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "ZeroBias v2 client + SDK example app (Next.js). Canonical patterns for building a custom app on the ZeroBias platform.",
   "scripts": {

--- a/package/zerobias/example-nextjs-v2/src/components/UserMenu.tsx
+++ b/package/zerobias/example-nextjs-v2/src/components/UserMenu.tsx
@@ -7,6 +7,9 @@ import { OrgSwitcher } from "./OrgSwitcher";
 import { CreateApiKeyDialog } from "./CreateApiKeyDialog";
 import { CreateSharedSessionDialog } from "./CreateSharedSessionDialog";
 
+// Inlined at build from package.json (see next.config.ts).
+const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION;
+
 function initials(name?: string): string {
   if (!name) return "?";
   const parts = name.trim().split(/[\s-]+/).filter(Boolean);
@@ -115,6 +118,9 @@ export function UserMenu() {
           <button className="menu-item" onClick={logout}>
             <span className="material-symbols-outlined">logout</span>
             <span className="menu-item-label">Sign Out</span>
+            {APP_VERSION && (
+              <span className="menu-item-version">v{APP_VERSION}</span>
+            )}
           </button>
         </div>
       )}

--- a/package/zerobias/example-nextjs-v2/src/styles/_user-menu.scss
+++ b/package/zerobias/example-nextjs-v2/src/styles/_user-menu.scss
@@ -213,6 +213,13 @@
   font-size: 26px;
   color: var(--zb-primary);
 }
+// App version, right-aligned in the Sign Out row (label's flex-grow pushes it).
+.menu-item .menu-item-version {
+  flex-shrink: 0;
+  font-size: var(--zb-font-size-xs);
+  color: var(--zb-secondary-text);
+  font-variant-numeric: tabular-nums;
+}
 
 // Avatar sizes (shared with header)
 .avatar-lg {


### PR DESCRIPTION
Adds the running app version on the right of the **Sign Out** row in the account dropdown (matches the requested layout: `Sign Out … v0.2.2`).

- `next.config.ts` — reads `package.json` version at build, inlines it as `NEXT_PUBLIC_APP_VERSION` (single source of truth).
- `UserMenu.tsx` — renders `v{version}` after the Sign Out label (right-aligned via the label's `flex-grow`).
- `_user-menu.scss` — `.menu-item-version`: small (`--zb-font-size-xs`), dim (`--zb-secondary-text`), tabular numerals.
- Bump `0.2.1 -> 0.2.2`; CHANGELOG entry.

## ⚠️ Stacks on #76
This branch is based on the 0.2.1 Hub-auth fix branch, so it **contains PR #76's commit** (`c0be96e`) as well as the version commit. Two clean ways to land:
- Merge **#76 first** (verify the Hub-auth fix on uat), then this PR's diff collapses to just the version change; **or**
- Merge **this** PR (delivers 0.2.1 + 0.2.2 together) and close #76.

Your call on ordering — the version sequence is linear either way (0.2.0 → 0.2.1 → 0.2.2).

## Test plan
- [ ] tsc 0 errors, eslint clean (verified locally).
- [ ] After deploy to uat: open the account menu → `v0.2.2` shows on the Sign Out row.
- [ ] Layout previewed in DevTools against the live uat menu — matches the sketch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)