### PR TITLE
feat(auditcrowd): forward the signed-in user's ZB session to the customer backend

### DIFF
--- a/package/raghu/auditcrowd/.env.production
+++ b/package/raghu/auditcrowd/.env.production
@@ -3,3 +3,6 @@
 # host from location.host at runtime, so no per-env API hostname is baked in.
 NEXT_PUBLIC_IS_LOCAL_DEV=false
 NEXT_PUBLIC_BASE_PATH=/auditcrowd
+# The AuditCrowd customer backend (absolute — the portal build has no /backend proxy).
+# Its /zb seam validates the forwarded ZB session against ZeroBias on every request.
+NEXT_PUBLIC_BACKEND_BASE=https://auditcrowd.runningbulltech.com/api

--- a/package/raghu/auditcrowd/src/app/engagement/page.tsx
+++ b/package/raghu/auditcrowd/src/app/engagement/page.tsx
@@ -8,8 +8,8 @@ import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import AppToolbar from "@/components/ui/appToolbar";
+import { backendHeaders } from "@/lib/backend";
 
-const ZB_KEY = process.env.NEXT_PUBLIC_API_KEY;
 const BACKEND = process.env.NEXT_PUBLIC_BACKEND_BASE ?? "/backend";
 
 function isPendingVal(v: unknown): boolean {
@@ -45,7 +45,7 @@ function EngagementInner() {
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
-    const headers: Record<string, string> = ZB_KEY ? { Authorization: `APIKey ${ZB_KEY}` } : {};
+    const headers = backendHeaders();
     fetch(`${BACKEND}/zb/opportunity/${id}`, { headers }).then((r) => (r.ok ? r.json() : null)).then(setDetail).catch(() => {});
     fetch(`${BACKEND}/zb/contract/${id}`, { headers }).then((r) => (r.ok ? r.json() : null)).then(setContract).catch(() => {});
   }, [id]);
@@ -54,7 +54,7 @@ function EngagementInner() {
 
   async function accept() {
     setSubmitting(true);
-    const headers: Record<string, string> = ZB_KEY ? { Authorization: `APIKey ${ZB_KEY}` } : {};
+    const headers = backendHeaders();
     try {
       const r = await fetch(`${BACKEND}/zb/accept/${id}`, { method: "POST", headers });
       if (r.ok) setReceipt(await r.json());

--- a/package/raghu/auditcrowd/src/app/page.tsx
+++ b/package/raghu/auditcrowd/src/app/page.tsx
@@ -4,8 +4,8 @@ import { useRouter } from "next/navigation";
 import { ShieldCheck, ListChecks, Fingerprint, Layers, BadgeCheck } from "lucide-react";
 import AppToolbar from "@/components/ui/appToolbar";
 import { useCurrentUser } from "@/context/CurrentUserContext";
+import { backendHeaders } from "@/lib/backend";
 
-const ZB_KEY = process.env.NEXT_PUBLIC_API_KEY;
 const BACKEND = process.env.NEXT_PUBLIC_BACKEND_BASE ?? "/backend";
 
 function initials(name?: string): string {
@@ -169,7 +169,7 @@ export default function Dashboard() {
   async function openDetail(id: string) {
     setDetailOpen(true);
     setDetail(null);
-    const headers: Record<string, string> = ZB_KEY ? { Authorization: `APIKey ${ZB_KEY}` } : {};
+    const headers = backendHeaders();
     try {
       const r = await fetch(`${BACKEND}/zb/opportunity/${id}`, { headers });
       if (r.ok) setDetail(await r.json());
@@ -179,7 +179,7 @@ export default function Dashboard() {
   }
 
   useEffect(() => {
-    const headers: Record<string, string> = ZB_KEY ? { Authorization: `APIKey ${ZB_KEY}` } : {};
+    const headers = backendHeaders();
     // The customer-backend seam: our own AuditCrowd API validates the ZB identity.
     // Its success is what makes the "Live on the ZeroBias transparency architecture"
     // pill a REAL verification, not a static label.

--- a/package/raghu/auditcrowd/src/lib/backend.ts
+++ b/package/raghu/auditcrowd/src/lib/backend.ts
@@ -1,0 +1,30 @@
+/**
+ * Auth headers for calls to the AuditCrowd backend (`NEXT_PUBLIC_BACKEND_BASE`).
+ *
+ * The backend's ZB seam is token-agnostic — it forwards whatever credential we send to
+ * ZeroBias's `/dana/me` for validation. Two sources, in order:
+ *
+ *  - Local dev: the API key from `.env.development` (`Authorization: APIKey <key>`).
+ *  - Deployed (uat/qa/prod): the signed-in user's OWN ZeroBias session id, which the v2
+ *    client keeps in `sessionStorage['dana-session-id']` (`Authorization: Session <id>`).
+ *    This is what makes the backend resolve the REAL logged-in user instead of falling
+ *    back to its shared service identity.
+ *
+ * No credential at all (SSR, or storage unavailable) sends no header — the backend then
+ * resolves its service identity, exactly as before.
+ */
+const DANA_SESSION_ID_KEY = "dana-session-id";
+
+export function backendHeaders(): Record<string, string> {
+  const key = process.env.NEXT_PUBLIC_API_KEY;
+  if (key) return { Authorization: `APIKey ${key}` };
+  try {
+    const sid = typeof window !== "undefined"
+      ? window.sessionStorage.getItem(DANA_SESSION_ID_KEY)
+      : null;
+    if (sid) return { Authorization: `Session ${sid}` };
+  } catch {
+    // sessionStorage can throw in sandboxed iframes — treat as "no credential".
+  }
+  return {};
+}


### PR DESCRIPTION
Follow-up to #75. Two small changes inside `package/raghu/auditcrowd` only:

1. **`.env.production`** — set `NEXT_PUBLIC_BACKEND_BASE=https://auditcrowd.runningbulltech.com/api`. Deployed builds had no backend base, so the app's customer-backend calls (`/backend/zb/*`) resolved against the portal origin and went nowhere.
2. **Forward the user's own session to that backend** — a tiny `backendHeaders()` helper sends `Authorization: Session <sessionStorage['dana-session-id']>` (the same credential the v2 client already holds) on customer-backend calls; local dev keeps the APIKey path. The AuditCrowd backend validates the forwarded credential against Dana `/dana/me` on every request — Dana stays the sole validator, and the signed-in user resolves as themselves instead of the backend's shared service identity.

No platform/SDK code touched; no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)