### PR TITLE
fix(auditcrowd): hydrate the session id in standalone mode

### DIFF
--- a/package/raghu/auditcrowd/src/lib/zerobias-app-service.ts
+++ b/package/raghu/auditcrowd/src/lib/zerobias-app-service.ts
@@ -20,6 +20,7 @@ import { env } from "./env";
 export class ZerobiasAppService {
   readonly api: ZerobiasClientApi;
   readonly app: ZerobiasClientApp;
+  private readonly sessionId: ZerobiasClientSessionId;
 
   private constructor() {
     const environment: ZbEnvironment = {
@@ -31,6 +32,7 @@ export class ZerobiasAppService {
 
     const orgId = new ZerobiasClientOrgId();
     const sessionId = new ZerobiasClientSessionId();
+    this.sessionId = sessionId;
     this.api = new ZerobiasClientApi(orgId, sessionId, environment);
     this.app = new ZerobiasClientApp(this.api, orgId, sessionId, environment);
   }
@@ -47,6 +49,21 @@ export class ZerobiasAppService {
     });
     // If there is no valid session (and we're not in local dev), init() has
     // already triggered the client's redirect to the platform login by now.
+
+    // Standalone (cookie-session) mode: the SDK writes sessionStorage['dana-session-id']
+    // ONLY from the portal-iframe postMessage, so a user who arrived via the platform
+    // login redirect holds a cookie but no header-transportable credential — and
+    // customer-backend calls (src/lib/backend.ts) would fall back to the backend's
+    // unattributed service identity. Hydrate it from Dana: GET /me/session returns the
+    // current session id, authenticated by the same-origin cookie.
+    if (!env.isLocalDev && !this.sessionId.getCurrentSessionId()) {
+      try {
+        const sid = await this.api.danaClient.getMeApi().ensureSession();
+        if (sid) this.sessionId.setCurrentSessionId(sid);
+      } catch {
+        // Backend calls stay unattributed; ZB SDK calls are unaffected (cookie).
+      }
+    }
   }
 
   static async create(): Promise<ZerobiasAppService> {


### PR DESCRIPTION
Follow-up to #78 — one file, `package/raghu/auditcrowd` only.

#78 forwards `sessionStorage['dana-session-id']` to the AuditCrowd customer backend, but the v2 client only writes that key from the **portal-iframe postMessage** (`zerobias-client-app` message handler). A user signing in **standalone** via the platform login redirect holds a same-origin session cookie and nothing else — so the forwarded header was never attached and backend calls fell back to the backend's shared service identity (verified live after #78 deployed: the first real login still resolved as the service-key owner).

Fix: after `app.init()`, when the key is absent and not in local dev, hydrate it via `danaClient.getMeApi().ensureSession()` (`GET /me/session`, authenticated by the cookie) and store it with the SDK's own `ZerobiasClientSessionId`. Iframe and local-dev paths untouched; failure is swallowed (backend calls just stay unattributed, ZB SDK calls unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)