### PR TITLE
chore(example-nextjs-v2): bump zerobias-client to 2.0.14 (standalone-session fix)

### DIFF
--- a/package/zerobias/example-nextjs-v2/package-lock.json
+++ b/package/zerobias/example-nextjs-v2/package-lock.json
@@ -11,7 +11,7 @@
         "@auditlogic/hub-sdk-github-github": "^7.1.6",
         "@zerobias-com/dana-sdk": "^2.0.4",
         "@zerobias-com/portal-sdk": "^2.0.2",
-        "@zerobias-com/zerobias-client": "^2.0.5",
+        "@zerobias-com/zerobias-client": "^2.0.14",
         "@zerobias-org/types-core-js": "^2.0.3",
         "@zerobias-org/util-connector": "^2.0.2",
         "axios": "^1.16.0",
@@ -3653,9 +3653,9 @@
       }
     },
     "node_modules/@zerobias-com/zerobias-client": {
-      "version": "2.0.13",
-      "resolved": "https://pkg.zerobias.org/@zerobias-com/zerobias-client/-/3fe32124827995b85003acd93a82603bd9e9fa0a",
-      "integrity": "sha512-q6uI3vbfZv/ZB1ahQ3qYtfHwE85LhoJbHC0nZJwgwMC+27XgLHS3jWycGz1bY/bB92PvXtg6DX2ijAl4eoeVDA==",
+      "version": "2.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-com/zerobias-client/-/7b222f60f6f6154f14ba1249c97d632dc9f40a58",
+      "integrity": "sha512-OGNRbIVHunttxaVRJbwywZxJim62EaWYNzOdLbkpcfzofDRJ0Y8gen+EaiE8eXuIwGiCFoqS5SMLF3TbyZAbuA==",
       "license": "ISC",
       "dependencies": {
         "@zerobias-com/hub-error-library": "^2.0.6",

--- a/package/zerobias/example-nextjs-v2/package.json
+++ b/package/zerobias/example-nextjs-v2/package.json
@@ -16,7 +16,7 @@
     "@auditlogic/hub-sdk-github-github": "^7.1.6",
     "@zerobias-com/dana-sdk": "^2.0.4",
     "@zerobias-com/portal-sdk": "^2.0.2",
-    "@zerobias-com/zerobias-client": "^2.0.5",
+    "@zerobias-com/zerobias-client": "^2.0.14",
     "@zerobias-org/types-core-js": "^2.0.3",
     "@zerobias-org/util-connector": "^2.0.2",
     "axios": "^1.16.0",


### PR DESCRIPTION
## What

Bumps `@zerobias-com/zerobias-client` `^2.0.5` → `^2.0.14` in `example-nextjs-v2` (lockfile pinned to 2.0.14).

## Why

2.0.14 ships the standalone-session hydration fix — **zerobias-com/clients#42** (merged, published):

`ZerobiasClientApi.init()` now resolves the session id from Dana (`GET /me/session`, cookie-authed) for **standalone (non-iframe) logins** — the mode this app runs in on uat/qa/prod. Previously the session id was written only by the portal-iframe postMessage, so `getZerobiasSessionId()` stayed `null` in standalone, and the GitHub Hub connect on `/module` sent no `Authorization: session <id>` header → dana proxy `401`.

This bump is what actually delivers that fix to the deployed app.

## Verification
- [x] `npm install` clean; `@zerobias-com/zerobias-client@2.0.14` resolved.
- [x] `tsc --noEmit` passes against 2.0.14.
- [ ] **In the wild (uat):** standalone login → `/module` → pick a good connection → the `metadata` call sends `Authorization: session <id>` and returns 200 + repos (no 401).

## Notes
- Supersedes an app-level workaround that was drafted in `zerobias-app-service.ts` and reverted in favor of the client-layer fix.
- The auditcrowd twin workaround (#79, just merged to uat) is now also redundant with 2.0.14 — separate cleanup, not in this PR.