### PR TITLE
chore(auditcrowd): revert #79 workaround, adopt zerobias-client 2.0.14

### DIFF
--- a/package/raghu/auditcrowd/package-lock.json
+++ b/package/raghu/auditcrowd/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@zerobias-com/dana-sdk": "^2.0.4",
         "@zerobias-com/portal-sdk": "^2.0.2",
-        "@zerobias-com/zerobias-client": "^2.0.5",
+        "@zerobias-com/zerobias-client": "^2.0.14",
         "@zerobias-org/types-core-js": "^2.0.3",
         "axios": "^1.16.0",
         "lucide-react": "^1.24.0",
@@ -3746,9 +3746,9 @@
       }
     },
     "node_modules/@zerobias-com/zerobias-client": {
-      "version": "2.0.13",
-      "resolved": "https://pkg.zerobias.org/@zerobias-com/zerobias-client/-/3fe32124827995b85003acd93a82603bd9e9fa0a",
-      "integrity": "sha512-q6uI3vbfZv/ZB1ahQ3qYtfHwE85LhoJbHC0nZJwgwMC+27XgLHS3jWycGz1bY/bB92PvXtg6DX2ijAl4eoeVDA==",
+      "version": "2.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-com/zerobias-client/-/7b222f60f6f6154f14ba1249c97d632dc9f40a58",
+      "integrity": "sha512-OGNRbIVHunttxaVRJbwywZxJim62EaWYNzOdLbkpcfzofDRJ0Y8gen+EaiE8eXuIwGiCFoqS5SMLF3TbyZAbuA==",
       "license": "ISC",
       "dependencies": {
         "@zerobias-com/hub-error-library": "^2.0.6",

--- a/package/raghu/auditcrowd/package.json
+++ b/package/raghu/auditcrowd/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@zerobias-com/dana-sdk": "^2.0.4",
     "@zerobias-com/portal-sdk": "^2.0.2",
-    "@zerobias-com/zerobias-client": "^2.0.5",
+    "@zerobias-com/zerobias-client": "^2.0.14",
     "@zerobias-org/types-core-js": "^2.0.3",
     "axios": "^1.16.0",
     "lucide-react": "^1.24.0",

--- a/package/raghu/auditcrowd/src/lib/zerobias-app-service.ts
+++ b/package/raghu/auditcrowd/src/lib/zerobias-app-service.ts
@@ -20,7 +20,6 @@ import { env } from "./env";
 export class ZerobiasAppService {
   readonly api: ZerobiasClientApi;
   readonly app: ZerobiasClientApp;
-  private readonly sessionId: ZerobiasClientSessionId;
 
   private constructor() {
     const environment: ZbEnvironment = {
@@ -32,7 +31,6 @@ export class ZerobiasAppService {
 
     const orgId = new ZerobiasClientOrgId();
     const sessionId = new ZerobiasClientSessionId();
-    this.sessionId = sessionId;
     this.api = new ZerobiasClientApi(orgId, sessionId, environment);
     this.app = new ZerobiasClientApp(this.api, orgId, sessionId, environment);
   }
@@ -49,21 +47,6 @@ export class ZerobiasAppService {
     });
     // If there is no valid session (and we're not in local dev), init() has
     // already triggered the client's redirect to the platform login by now.
-
-    // Standalone (cookie-session) mode: the SDK writes sessionStorage['dana-session-id']
-    // ONLY from the portal-iframe postMessage, so a user who arrived via the platform
-    // login redirect holds a cookie but no header-transportable credential — and
-    // customer-backend calls (src/lib/backend.ts) would fall back to the backend's
-    // unattributed service identity. Hydrate it from Dana: GET /me/session returns the
-    // current session id, authenticated by the same-origin cookie.
-    if (!env.isLocalDev && !this.sessionId.getCurrentSessionId()) {
-      try {
-        const sid = await this.api.danaClient.getMeApi().ensureSession();
-        if (sid) this.sessionId.setCurrentSessionId(sid);
-      } catch {
-        // Backend calls stay unattributed; ZB SDK calls are unaffected (cookie).
-      }
-    }
   }
 
   static async create(): Promise<ZerobiasAppService> {


### PR DESCRIPTION
Per Clark — clients#42 shipped the session-id hydration in the client itself (`ClientApi.init()` now resolves it via `ensureSession()` for standalone logins), so the app-layer workaround is no longer needed.

- **Revert #79 in full** (`git revert 885de4b`): the hydration block and the private `sessionId` field it added come out; `zerobias-app-service.ts` returns to its pre-#79 shape.
- **Bump `@zerobias-com/zerobias-client` to `^2.0.14`** (lock pins 2.0.14). Verified the installed package contains the hydration (`getMeApi().ensureSession()` → `setCurrentSessionId`).
- **#78 unchanged** — the client writes the same `sessionStorage['dana-session-id']` key the backend-forwarding helper reads.

Typecheck clean. `package/raghu/auditcrowd` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)