### PR TITLE
fix(ci): scope Lint to sme-mart changes and fix the push-event diff base

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,18 @@ name: Lint
 
 on:
   pull_request:
+    paths:
+      - 'package/w3geekery/sme-mart/**'
+      - '.github/workflows/lint.yml'
   push:
     branches-ignore:
       - main
       - uat
       - qa
       - prod
+    paths:
+      - 'package/w3geekery/sme-mart/**'
+      - '.github/workflows/lint.yml'
 
 permissions:
   contents: read
@@ -59,5 +65,28 @@ jobs:
         # workspace resolve to the temp-dir install.
         run: ln -s "${RUNNER_TEMP}/lint-tools/node_modules" node_modules
 
+      - name: Resolve diff base
+        # pull_request: base_ref is the target branch, so diff against it.
+        # push: base_ref is EMPTY. The old fallback was origin/poc/sme-mart —
+        # a ref hundreds of commits diverged from uat — so a push on any branch
+        # diffed its whole history against it and linted every sme-mart file.
+        # Use the push's own previous SHA instead; on a branch's first push
+        # that SHA is all-zeros, so fall back to the merge-base with uat.
+        id: base
+        working-directory: ${{ github.workspace }}
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE: ${{ github.event.before }}
+        run: |
+          if [ -n "$BASE_REF" ]; then
+            base="origin/$BASE_REF"
+          elif [ -n "$BEFORE" ] && git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            base="$BEFORE"
+          else
+            base="$(git merge-base HEAD origin/uat)"
+          fi
+          echo "Diff base: $base"
+          echo "ref=$base" >> "$GITHUB_OUTPUT"
+
       - name: Lint changed files (diff-based)
-        run: npx lint-staged --diff="origin/${{ github.base_ref || 'poc/sme-mart' }}...HEAD"
+        run: npx lint-staged --diff="${{ steps.base.outputs.ref }}...HEAD"


### PR DESCRIPTION
## Problem

The `Lint` workflow red-X'd on the **push** event for branches that touch no SME Mart files at all — every `example-nextjs-v2` branch, for instance. Same commit, same workflow: the `pull_request` run passes, the `push` run fails.

Run history on `chore/bump-zerobias-client-2.0.14` (one commit, two runs):

| Event | Result |
|---|---|
| `pull_request` | success (27s) |
| `push` | **failure** (35s) |

## Two causes, both fixed here

**1. No `paths` filter.** The job is hardcoded to `working-directory: package/w3geekery/sme-mart`, but ran on every push to every branch (only `main`/`uat`/`qa`/`prod` were ignored). It now runs only when SME Mart files — or this workflow itself — actually change.

**2. Stale push-event diff base.** `github.base_ref` is empty on `push`, so the diff base `origin/${{ github.base_ref || 'poc/sme-mart' }}` fell back to `origin/poc/sme-mart` — a real ref on this remote, hundreds of commits diverged from `uat`. The branch's entire history got diffed against it, sweeping in every SME Mart file and linting SME Mart's pre-existing errors. That's the red X.

The base is now resolved explicitly: the target branch on `pull_request`, the push's own previous SHA (`github.event.before`) on `push`, and the merge-base with `uat` on a branch's first push, where that SHA is all-zeros.

Net effect: the push event now agrees with the pull_request event, which was already green.

## Test plan

- [x] YAML parses; triggers and step list verified
- [ ] This PR's own `pull_request` run is green (it touches `.github/workflows/lint.yml`, which is in the `paths` filter, so the workflow deliberately self-tests)
- [ ] The `push` run on this branch is green — the failure mode being fixed
- [ ] After merge: a push to a fresh `example-nextjs-v2` branch triggers **no** Lint run at all
- [ ] After merge: a push touching `package/w3geekery/sme-mart/**` still lints, and only the changed files

## Scope

`lint.yml` exists only on `uat` and the fork's `poc/sme-mart` — `qa` and `main` don't carry the file, so there is no promote chain. A matching PR against `poc/sme-mart` in `w3geekery/app` follows separately.

Note: a `push` event uses the workflow file from the branch being pushed, so already-open branches keep the broken copy until rebased on `uat`. New branches get the fix for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)