### PR TITLE
deploy(sme-mart): fix bootstrap crash — pin client family to ui's set

### DIFF
--- a/package/w3geekery/sme-mart/package-lock.json
+++ b/package/w3geekery/sme-mart/package-lock.json
@@ -34,10 +34,10 @@
         "@neondatabase/serverless": "^1.0.2",
         "@ngx-translate/core": "^15.0.0",
         "@ngx-translate/http-loader": "^17.0.0",
-        "@zerobias-com/zerobias-angular-client": "^2.0.13",
+        "@zerobias-com/zerobias-angular-client": "2.0.17",
         "@zerobias-org/data-utils": "^2.1.7",
         "@zerobias-org/ngx-library": "^0.2.43",
-        "@zerobias-org/types-core-js": "^2.0.4",
+        "@zerobias-org/types-core-js": "2.0.3",
         "dompurify": "^3.3.1",
         "marked": "^17.0.3",
         "ngx-infinite-scroll": "^21.0.0",
@@ -6313,13 +6313,13 @@
       }
     },
     "node_modules/@zerobias-com/zerobias-angular-client": {
-      "version": "2.0.18",
-      "resolved": "https://pkg.zerobias.org/@zerobias-com/zerobias-angular-client/-/d082dc9e7c9e0936e9b78c99e859c72ad78092a3",
-      "integrity": "sha512-npj6Xs2ymwkRTdY4f1zWWdegOReqpB5wMNVNX9m10OO+CLJ1g8SaOj1V0zFBIMcKM3k52y6xVdu0qvrcD8ECKA==",
+      "version": "2.0.17",
+      "resolved": "https://pkg.zerobias.org/@zerobias-com/zerobias-angular-client/-/23ef7ae57e0217073b075fe4a26d1171661b7802",
+      "integrity": "sha512-lFAwbFsHZnaM4xbxPZHMpIJEmvYFDD64HggfVKUqqNZlZlHsg5jkEjMF2mIJvnrC0V/Wdfdthj6j3PbjdwsSWA==",
       "license": "ISC",
       "dependencies": {
         "@angular/core": "^21.0.0",
-        "@zerobias-com/zerobias-client": "^2.0.18",
+        "@zerobias-com/zerobias-client": "^2.0.17",
         "tslib": "^2.0.0"
       },
       "engines": {
@@ -6328,13 +6328,13 @@
       }
     },
     "node_modules/@zerobias-com/zerobias-client": {
-      "version": "2.0.18",
-      "resolved": "https://pkg.zerobias.org/@zerobias-com/zerobias-client/-/872f0c66f89e1a7db36dfe0742e4275d87da187a",
-      "integrity": "sha512-sDzAfsEYVh2J476ZGpB/ceAFQVPo35kCQcET/arjdeeMKJ483OmI71LWxMOrN5vJ4VeM33HHUd2SFbiKK+E+9A==",
+      "version": "2.0.17",
+      "resolved": "https://pkg.zerobias.org/@zerobias-com/zerobias-client/-/5d35871c16827b10bba1664efa0d9f281c1a46be",
+      "integrity": "sha512-uMeOuiR0zTa/uReqjMqBw/CqYh5e5uMjoKfB0sy+gUNLzFQv0kKNAC+quTMGWBl0yx/UNocltVZk3Gt9yG/FKw==",
       "license": "ISC",
       "dependencies": {
-        "@zerobias-com/hub-error-library": "^2.0.10",
-        "@zerobias-com/zerobias-sdk": "^2.0.14",
+        "@zerobias-com/hub-error-library": "^2.0.6",
+        "@zerobias-com/zerobias-sdk": "^2.0.13",
         "@zerobias-org/types-core-js": "2.0.4",
         "js-beautify": "^1.0.0",
         "rxjs": "^7.0.0"
@@ -6517,19 +6517,20 @@
       "version": "2.0.2",
       "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core/-/types-core-2.0.2.tgz",
       "integrity": "sha512-83LVwMlF/tnUaUi5GHIAXBoYLL/0ITQvU0G0jAcEMFcu8uU/nYyj3ix4D226+SjDMT0PEfxg3bWd2nGJwVf+IA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@zerobias-org/types-core-js": {
-      "version": "2.0.4",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core-js/-/types-core-js-2.0.4.tgz",
-      "integrity": "sha512-mZAp/WekeW1yZ8O735Whsvfu8gfC90hywW8jHjQxjERKXsM184vOJqcVUWoWVC/Jx0QqB3smFnijiVfaUqnTsQ==",
+      "version": "2.0.3",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core-js/-/types-core-js-2.0.3.tgz",
+      "integrity": "sha512-u+q9IkaQ+nBhqFHg0yqnhlz3tpLHvdbvpqYJ9+EgYdKVzsLLHnlXvXV365JTOXXu9UgVBY+/3U9bFpqvOpYHNg==",
       "license": "ISC",
       "dependencies": {
-        "@zerobias-org/types-core": "2.0.2",
+        "@zerobias-org/types-core": "2.0.1",
         "awesome-phonenumber": "^7.6.0",
         "axios": "^1.16.0",
         "cron-parser": "^5.4.0",
-        "ip-num": "1.5.1",
+        "ip-num": "^1.5.1",
         "iso8601-duration": "^2.1.2",
         "p-limit": "^6.2.0",
         "pluralize-esm": "^9.0.5",
@@ -6541,6 +6542,12 @@
       "engines": {
         "node": ">=22.0.0"
       }
+    },
+    "node_modules/@zerobias-org/types-core-js/node_modules/@zerobias-org/types-core": {
+      "version": "2.0.1",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core/-/types-core-2.0.1.tgz",
+      "integrity": "sha512-y2IAVF74u2gIUNdwTK2HaGYAuGQHaKQM0yV3POCbTSiJSZf+wopdLS6SnbCX8VmxlrYbsr49t7Qb9lGRjYMNqg==",
+      "license": "ISC"
     },
     "node_modules/@zerobias-org/util-api-client-base": {
       "version": "2.0.1",
@@ -9304,9 +9311,10 @@
       }
     },
     "node_modules/ip-num": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ip-num/-/ip-num-1.5.1.tgz",
-      "integrity": "sha512-QziFxgxq3mjIf5CuwlzXFYscHxgLqdEdJKRo2UJ5GurL5zrSRMzT/O+nK0ABimoFH8MWF8YwIiwECYsHc1LpUQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ip-num/-/ip-num-1.6.1.tgz",
+      "integrity": "sha512-BslnUVM6qE7gDSUPRtY3lqCdtC3sd50KCPHHnmFR2ak3obqW5lL0Izo5n1afUxk5vWWvi/MBuPKkRaZ+3aoSnw==",
+      "hasInstallScript": true,
       "license": "MIT"
     },
     "node_modules/ipaddr.js": {

--- a/package/w3geekery/sme-mart/package.json
+++ b/package/w3geekery/sme-mart/package.json
@@ -56,7 +56,9 @@
     "@zerobias-org/types-core-js": "$@zerobias-org/types-core-js",
     "@zerobias-org/util-connector": "1.0.40",
     "@zerobias-org/util-connector@1.0.41": "1.0.40",
-    "@zerobias-com/zerobias-sdk": "2.0.13"
+    "@zerobias-com/zerobias-sdk": "2.0.13",
+    "@zerobias-com/zerobias-client": "2.0.17",
+    "@zerobias-com/zerobias-angular-client": "2.0.17"
   },
   "dependencies": {
     "@acrodata/code-editor": "^0.6.0",
@@ -85,10 +87,10 @@
     "@neondatabase/serverless": "^1.0.2",
     "@ngx-translate/core": "^15.0.0",
     "@ngx-translate/http-loader": "^17.0.0",
-    "@zerobias-com/zerobias-angular-client": "^2.0.13",
+    "@zerobias-com/zerobias-angular-client": "2.0.17",
     "@zerobias-org/data-utils": "^2.1.7",
     "@zerobias-org/ngx-library": "^0.2.43",
-    "@zerobias-org/types-core-js": "^2.0.4",
+    "@zerobias-org/types-core-js": "2.0.3",
     "dompurify": "^3.3.1",
     "marked": "^17.0.3",
     "ngx-infinite-scroll": "^21.0.0",


### PR DESCRIPTION
## What

The app deployed by #98 **crashes at bootstrap** on UAT:
`Cannot read properties of undefined (reading 'MESSAGE_KEY')` in `types-core-js` error-library registration.

**Root cause:** `@zerobias-com/zerobias-client@2.0.18` expects `sdk 2.0.14`'s error-library shape, but we force `sdk 2.0.13` (proxy install index lags) → an undefined error class → crash.

**Fix:** pin the `@zerobias-com` client family to **`zb/com/ui`'s exact production set**:
- `zerobias-angular-client` **2.0.17** · `zerobias-client` **2.0.17** · `zerobias-sdk` **2.0.13** · `types-core-js` **2.0.3**

ui runs this exact set without the crash. Verified: `npm install` + `ng build` pass locally; installed versions match ui.

2-file change (`package.json` + lock). App `src/` already on uat.

## Deploy target
uat.zerobias.com/sme-mart

🤖 Generated with [Claude Code](https://claude.com/claude-code)