### PR TITLE
docs(app): correct deploy docs against the actual pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,9 @@ canonical set; the reference for new work is always `example-nextjs-v2`.)
 ### Why the depth and the org-slug matter
 
 The deploy detector (`.github/workflows/dispatch.yml`) matches changed files
-against `package/*/*/**` and derives the app from the **first two path
-segments** (`awk -F/ '{print $1"/"$2"/"$3}'`). Consequences:
+against `package/*/*/**` and derives the app from the **first three path
+segments** — `package/<org>/<app>` (`awk -F/ '{print $1"/"$2"/"$3}'`).
+Consequences:
 
 - The app must be **exactly two levels** under `package/`. Shallower or deeper
   nesting is not detected/deployed.
@@ -128,8 +129,13 @@ SSO redirect, `nextPath`, the local-dev API-key interceptor) see
 
 Each app folder must have:
 
-- `.nvmrc` — Node **>= 22** (v2 client engine requirement). CI installs from
-  this. (Legacy v1 apps may pin an older version via their own `.nvmrc`.)
+- `.nvmrc` — Node **>= 22** (v2 client engine requirement). ⚠️ CI's `setup-node`
+  reads the **repo-root** `.nvmrc` (`22.21.1`), **not** the app's:
+  `node-version-file: '.nvmrc'` in the deploy action resolves from the workspace
+  root, and the step has no `working-directory`. The app's own `.nvmrc` governs
+  local dev only — pinning a newer Node in an app folder does **not** change the
+  CI build. Keep the two compatible, and bump the root file if an app genuinely
+  needs a newer runtime.
 - Committed `package-lock.json` — CI runs `npm ci`.
 - `.npmrc` — both `@zerobias-com` and `@zerobias-org` scopes resolve from
   `https://pkg.zerobias.org` with `${ZB_TOKEN}` (a single platform API key
@@ -148,20 +154,69 @@ Each app folder must have:
 > the same environment, open **two separate PRs** (one app subtree each) and
 > merge them one at a time. Same for env promotions (`uat → qa`, `uat → main`):
 > **one app per promotion branch.** Don't try to batch them.
+>
+> **Why only one deploys** (so nobody "fixes" the detector and assumes batching
+> is now safe): `tj-actions/changed-files` emits `all_modified_files` as a
+> **single space-separated line**, so `awk -F/` sees only the *first* file's path
+> and every changed app after the first is silently dropped. A two-app PR
+> deploys app #1 and says nothing about app #2 — no error, no warning.
 
-`.github/workflows/dispatch.yml` fires on push to `main` / `uat` / `qa`, finds
-the changed `package/<org>/<app>/**` app, and dispatches `deploy.yml`, which runs
-the `static-s3-app-release` action:
+`.github/workflows/dispatch.yml` fires on push to `main` / `uat` / `qa` / `dev`,
+finds the changed `package/<org>/<app>/**` app, and dispatches `deploy.yml`,
+which resolves the env from the branch, pulls the bucket / account / CloudFront
+distribution from **Vault** (`operations-kv/data/github/zb-org/app/<env>`), then
+runs the `static-s3-app-release` action:
 
 ```
-.nvmrc  ->  npm ci  ->  npm run build  ->  aws s3 sync <app>/dist  s3://app-<env>-zerobias.com/<app-name>/
+setup-node (root .nvmrc)  ->  npm ci  ->  npm run build   [in package/<org>/<app>]
+  ->  aws s3 sync <app>/dist  s3://<bucket>/<app-name>  --delete
+  ->  cloudfront create-invalidation  /<app-name>/*   (waits for completion)
+  ->  Slack #releases announcement
 ```
 
-| Branch | Env | Bucket |
+| Branch | `ENV_NAME` (Vault path + IAM role) | Serves at |
 |---|---|---|
-| `main` | prod | `app-app-zerobias.com` |
-| `uat`  | uat  | `app-uat-zerobias.com` |
-| `qa`   | qa   | `app-qa-zerobias.com` |
+| `main` | `prod` | `https://app.zerobias.com/<app-name>` |
+| `uat`  | **`demo`** | `https://uat.zerobias.com/<app-name>` |
+| `qa`   | `qa` | qa CDN |
+| `dev`  | `dev` | dev CDN |
+
+Note the `uat → demo` rename: the branch is `uat`, but the Vault path and the
+assumed role are `…/app/demo` and `gh-zb-org-app-demo-custom-ui`. Bucket names
+come from Vault, not from the workflow — don't assume `app-<branch>-zerobias.com`
+when debugging a failed deploy.
+
+The sync is `--delete` but scoped to the app's own `s3://<bucket>/<app-name>`
+prefix, so it can't disturb another app. Deploy is **build-from-source**: nothing
+about your local `dist/` is uploaded, and `dist/` stays gitignored.
+
+### ⚠️ Deep links only work for apps that emit per-route HTML
+
+The CDN has no SPA fallback (`custom_error_response` is commented out in
+`com/devops/modules/aws/ui/main.tf`). A CloudFront **viewer-request Lambda**
+(`default-app-vreq.tpl.mjs`) rewrites extension-less URIs by probing S3 in order:
+
+1. `<uri>.html` → 2. `<uri>/index.html` → 3. **bucket-root `/index.html`**
+
+Consequences, verified against UAT:
+
+- `/(<app-name>)/` **301-redirects** to `/<app-name>` (trailing slash stripped),
+  which resolves via rule 2 to the app's `index.html`. The entry URL is fine —
+  `<base href="/<app-name>/">` keeps assets resolving.
+- **Next.js static export works everywhere**: it emits `products.html` /
+  `products/index.html`, so rule 1/2 matches every route.
+- **A path-routed Angular SPA breaks on deep links.** Only one `index.html`
+  exists, so `/example-angular-v2/products` falls through to rule 3 and returns
+  **HTTP 200 serving the ZeroBias portal shell** (`<base href="/">`) — the wrong
+  app, with no error to make it obvious.
+
+In-app navigation (`routerLink`) is unaffected — it never hits the CDN — and the
+portal iframe always loads the entry URL, so this stays invisible until someone
+refreshes, bookmarks, shares a deep link, or gets bounced back by an SSO
+`nextPath` pointing at a sub-route. If a new Angular app needs working deep
+links, pick one: a post-build step that copies `index.html` to each route's
+`<route>/index.html`, Angular prerendering, or hash routing
+(`withHashLocation()`).
 
 **A commit to `main` is a production release.** For a new or risky app, land on
 a branch and push to `qa` first to smoke-test the deployed artifact, then promote


### PR DESCRIPTION
Doc-only corrections from researching the real deploy path before the first hl7-analyzer deploy (#100). Everything here was verified against `dispatch.yml`, `deploy.yml`, the `static-s3-app-release` action, the terraform in `com/devops/modules/aws/ui/`, and live UAT responses.

**No `package/` files touched, so this triggers no deploy.**

## What was wrong or missing

| Topic | Docs said | Actually |
|---|---|---|
| `.nvmrc` | "CI installs from this" (the app's) | CI's `setup-node` reads the **repo-root** `.nvmrc` (`22.21.1`) — `node-version-file: '.nvmrc'` resolves from the workspace root and the step sets no `working-directory`. An app-level pin does **not** change the CI build. |
| One-app-per-PR | "only one of them will deploy" (mechanism given as the awk path split) | True, but the real cause is that `changed-files` emits `all_modified_files` as a **single space-separated line**, so `awk -F/` only ever sees the first file's path. Worth stating so nobody "fixes" the awk and assumes batching is now safe. |
| Path depth | "first two path segments" | Three — `package/<org>/<app>`. |
| Branches | `main` / `uat` / `qa` | Also `dev`. |
| Env names | `uat` → env `uat` | `uat` → **`ENV_NAME=demo`**: Vault path `…/app/demo`, role `gh-zb-org-app-demo-custom-ui`. |
| Buckets | hardcoded table (`app-uat-zerobias.com`, …) | Pulled from Vault per env — don't assume `app-<branch>-zerobias.com` when debugging. |
| Deploy chain | ended at `s3 sync` | Also `--delete` (scoped to the app prefix), a CloudFront invalidation that **waits for completion**, and a Slack #releases announcement. |
| Deep links | not mentioned | See below. |

## New section: deep links only work for apps that emit per-route HTML

`custom_error_response` is commented out in `com/devops/modules/aws/ui/main.tf`, so there is no SPA fallback. A viewer-request Lambda (`default-app-vreq.tpl.mjs`) probes S3 in order: `<uri>.html` → `<uri>/index.html` → **bucket-root `/index.html`**.

Verified against UAT:

| URL | Result |
|---|---|
| `/example-angular-v2/` | 301 → `/example-angular-v2` (trailing slash stripped) |
| `/example-angular-v2` | 200, correct app |
| `/example-angular-v2/products` | 200, **serves the ZeroBias portal shell** (`<base href="/">`) |
| `/example-nextjs-v2/products` | 200, correct app |

Next.js static export emits `products.html` / `products/index.html`, so rules 1/2 match. A path-routed Angular SPA has only one `index.html` and falls through to rule 3 — the wrong app, at HTTP 200, with nothing to signal the failure. It stays invisible until someone refreshes, bookmarks, shares a deep link, or gets bounced back by an SSO `nextPath` pointing at a sub-route. The section lists the three available fixes (post-build route copies, Angular prerendering, hash routing).

The matching app-level caveats for hl7-analyzer are in #100; they reach `main` when that app is promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)