### PR TITLE
fix(sme-mart): .npmrc @zerobias-com -> pkg.zerobias.org with ZB_TOKEN (poc/sme-mart)

### DIFF
--- a/package/w3geekery/sme-mart/.npmrc
+++ b/package/w3geekery/sme-mart/.npmrc
@@ -1,8 +1,21 @@
+# All ZeroBias scopes resolve from pkg.zerobias.org, which proxies GitHub
+# Packages for the @zerobias-com scope. A single ZB_TOKEN authenticates them
+# all — and ZB_TOKEN is what deploy.yml actually sets. This matches the
+# canonical example-*-v2 / auditcrowd apps.
+#
+# Do NOT point @zerobias-com at npm.pkg.github.com directly. The deploy job
+# has no GITHUB_TOKEN at all (deploy.yml sets only ZB_TOKEN, and setup-node
+# runs without registry-url), so ${GITHUB_TOKEN} expands to an empty string
+# and npm sends a blank credential — GitHub Packages then returns
+# 401 "unauthenticated: User cannot be authenticated with the token provided."
+# This is an env-plumbing failure, not a token scope or expiry problem.
+#
+# Get a ZB_TOKEN by creating an API key in the ZeroBias platform, then:
+#   export ZB_TOKEN='<your api key>'
+# before running `npm install`.
 @auditmation:registry=https://pkg.zerobias.org
 @auditlogic:registry=https://pkg.zerobias.org
 @zerobias-org:registry=https://pkg.zerobias.org
+@zerobias-com:registry=https://pkg.zerobias.org
 //pkg.zerobias.org/:always-auth=true
 //pkg.zerobias.org/:_authToken=${ZB_TOKEN}
-
-@zerobias-com:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}


### PR DESCRIPTION
Fixes the broken `.npmrc` on `poc/sme-mart` that caused Deploy App 401s (runs 30125346041, 30127021560 on 7/24).

## Root cause (Chris Scarola, 2026-07-24)
`poc/sme-mart` pointed `@zerobias-com` at `npm.pkg.github.com` with `_authToken=${GITHUB_TOKEN}` — but the Deploy App job sets **only `ZB_TOKEN`** (no `GITHUB_TOKEN`, and setup-node runs without a registry-url). `${GITHUB_TOKEN}` expanded to an **empty string**, so npm sent a blank credential and GitHub Packages returned `401 "unauthenticated: User cannot be authenticated with the token provided."` — an env-plumbing failure, **not** a token scope/expiry problem (Chris verified the Vault `readPackagesToken` returns 302 on the exact tarball).

## Fix
Route `@zerobias-com` through `pkg.zerobias.org` on `ZB_TOKEN` like every other scope — the same fix already on `uat` (PR #98) and the canonical `example-*-v2` / auditcrowd apps. Comment block carries Chris's corrected diagnosis (blank-credential, not scope).

## Scope / safety
- One file: `package/w3geekery/sme-mart/.npmrc`. No code change.
- Base is `poc/sme-mart`, not an env branch — **no deploy triggered** by this PR.
- This is the surgical fix; a full `uat -> poc/sme-mart` merge is NOT appropriate (poc/sme-mart is the stale Next.js POC, 863 commits behind the Angular app on uat, diverged 2025-06).