### PR TITLE
fix(sme-mart): repair UAT bootstrap crash — MESSAGE_KEY undefined at module eval

### DIFF
--- a/package/w3geekery/sme-mart/src/main.ts
+++ b/package/w3geekery/sme-mart/src/main.ts
@@ -1,3 +1,27 @@
+// ⚠️ LOAD-BEARING SIDE-EFFECT IMPORT — MUST STAY FIRST. DO NOT REMOVE OR REORDER.
+//
+// Without it the app dies at module-eval time, before Angular bootstraps, with:
+//   Uncaught TypeError: Cannot read properties of undefined (reading 'MESSAGE_KEY')
+//     at CoreErrorLibrary.listKeys / CoreError.initWithLibrary
+//
+// Cause: CoreErrorLibrary builds a map of all 17 core error classes at module
+// scope. 16 of them are reached only through errors/index.js, but CoreType.js:4
+// deep-imports UnexpectedError directly from ./errors/UnexpectedError.js
+// instead of the barrel. That direct edge makes esbuild place UnexpectedError
+// in the *types* module cluster (next to DateTime), which evaluates AFTER
+// CoreErrorLibrary. Its `var` binding is therefore still undefined when the map
+// is built, the map bakes in `UnexpectedError: undefined`, and listKeys()
+// throws dereferencing it.
+//
+// Importing the barrel here first forces errors/index.js — and so all 17
+// classes — to be evaluated ahead of the library that captures them.
+//
+// Upstream fix is one line in @zerobias-org/types-core-js: CoreType.js should
+// import from ./errors/index.js like PagedResults.js:3 does. Still present in
+// 2.0.4 (we pin 2.0.3). Remove this import only after the package ships that
+// change AND a production build is verified.
+import '@zerobias-org/types-core-js';
+
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app.component';


### PR DESCRIPTION
## The problem

`uat.zerobias.com/sme-mart` is **white-screened** — has been since at least the Jul 24 deploy. The app dies at module-eval time, before Angular bootstraps:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'MESSAGE_KEY')
  at CoreErrorLibrary.listKeys / CoreError.initWithLibrary
```

Nothing renders. `app-root` has zero children. Because the crash precedes bootstrap, **no guard, no router, and no `whoAmI()` ever runs** — which is why it never redirected to login. Logging in does not help; the failure has no auth dependency.

## Root cause

`CoreErrorLibrary` builds a map of all 17 core error classes at module scope. 16 of them are reached only through `errors/index.js`, but **`CoreType.js:4` deep-imports `UnexpectedError` directly** from `./errors/UnexpectedError.js` instead of the barrel (compare `PagedResults.js:3`, which uses the barrel). That direct edge makes esbuild place `UnexpectedError` in the *types* module cluster, next to `DateTime` — which evaluates **after** `CoreErrorLibrary`. Its `var` binding is still `undefined` when the map is built, so the map bakes in `UnexpectedError: undefined` and `listKeys()` throws dereferencing it.

Measured in the deployed bundle (`chunk-6CONEQRE.js`):

| | offset |
|---|---|
| 16 error classes | 475,161 – 479,700 |
| the `ATe` map that captures them | 1,161,640 |
| `UnexpectedError` | **1,823,726** — 1.34M chars *after* the map |

## The fix

One side-effect import at the top of `main.ts`, forcing `errors/index.js` — and so all 17 classes — to evaluate ahead of the library that captures them. After the fix `UnexpectedError` is declared at **397,241**, adjacent to its siblings and before the map.

## Why not a version bump

`96ca210a` (Jul 24) addressed this same symptom by pinning the client family, stating *"Verified: build passes, versions match ui."* **Neither of those detects this bug** — the build is green and the crash is runtime-only. That is why it stayed live while local dev kept working: dev mode does not chunk this way, so `npm run dev` has never reproduced it.

Those pins are load-bearing and are left untouched. `types-core-js@2.0.4` still carries the same deep import, so upgrading does not fix it either.

## Verification — not "build passes"

- Built with the deploy config (`ng build --configuration uat --base-href=/sme-mart/`) and served the **real artifact** in a browser.
- **Zero `MESSAGE_KEY` errors.** Angular bootstraps, `whoAmI` runs, and `redirectLogin` fires — the redirect that could never happen before.
- `UnexpectedError` now constructs and throws correctly (visible as a normal session error), confirming the class is live rather than merely absent from the stack.
- Pre-fix local build was **byte-identical** to the deployed bundle (`sha256 72edcd3b…061d91`), confirming the reproduction was faithful and that a redeploy of the current commit could not have helped.

## Upstream

The real fix is one line in `@zerobias-org/types-core-js`: `CoreType.js` should import from `./errors/index.js` like `PagedResults.js:3` does. This shim should be removed only after that ships **and** a production build is verified in a browser.

## Test plan

- [ ] Merge to `uat`, run the Deploy App workflow (`app-name: sme-mart`, `app-path: package/w3geekery`)
- [ ] Invalidate the CloudFront distribution (`E23VJPBBDUCHBQ`, path `/*`)
- [ ] Load `uat.zerobias.com/sme-mart` — expect the app to render or redirect to login, and no `MESSAGE_KEY` error in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)